### PR TITLE
Initial bv literals support

### DIFF
--- a/ksmt-core/src/main/kotlin/example/Example.kt
+++ b/ksmt-core/src/main/kotlin/example/Example.kt
@@ -1,8 +1,8 @@
 package example
 
 import org.ksmt.KContext
-import org.ksmt.expr.KExpr
-import org.ksmt.sort.KBoolSort
+import org.ksmt.expr.KBitVec8Expr
+import org.ksmt.sort.KBV16Sort
 
 fun main() = with(KContext()) {
     val a = boolSort.mkConst("a")
@@ -12,9 +12,20 @@ fun main() = with(KContext()) {
     val e1 = (c.select(b) + (c.store(b, b).select(b) + b) eq c.select(b)) and a or !a
     val e2 = x.store(b, c).select(b).select(10.intExpr) ge 11.intExpr
     val z = 3
-}
 
-fun anyexpr(expr: KExpr<*>) = with(KContext()) {
-    expr as KExpr<KBoolSort>
-    expr.and(expr)
+    val bv8 = mkBV(0.toByte())
+    val byteBits = Byte.SIZE_BITS
+    // how to restrict such casts to avoid misscast? For example, you can write `as KBitVec16Expr` as well
+    val sameBv8 = mkBV("0".repeat(byteBits), byteBits.toUInt()) as KBitVec8Expr
+    check(bv8 === sameBv8)
+
+    val bv16Sort = mkBv16Sort()
+    val sameBv16Sort = mkBvSort(16.toUInt()) as KBV16Sort
+    check(bv16Sort === sameBv16Sort)
+
+    val bv32Decl = mkBvDecl(0)
+    val sameBv32Decl = mkBvDecl("0".repeat(32), 32.toUInt())
+    check(sameBv32Decl === bv32Decl)
+
+    check(bv32Decl.name == "#b${"0".repeat(32)}")
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/decl/KBitVecExprDecl.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/decl/KBitVecExprDecl.kt
@@ -1,0 +1,62 @@
+package org.ksmt.decl
+
+import org.ksmt.KContext
+import org.ksmt.expr.KApp
+import org.ksmt.expr.KExpr
+import org.ksmt.sort.KBV16Sort
+import org.ksmt.sort.KBV32Sort
+import org.ksmt.sort.KBV64Sort
+import org.ksmt.sort.KBV8Sort
+import org.ksmt.sort.KBVSort
+
+abstract class KBitVecExprDecl<T : KBVSort> internal constructor(ctx: KContext, val value: String, sort: T) :
+    KConstDecl<T>(ctx, "#b$value", sort) {
+
+    internal constructor(ctx: KContext, value: Number, sort: T) : this(ctx, value.toBinary(), sort)
+}
+
+class KBitVec8ExprDecl internal constructor(ctx: KContext, private val byteValue: Byte) :
+    KBitVecExprDecl<KBV8Sort>(ctx, byteValue, ctx.mkBv8Sort()) {
+    override fun apply(args: List<KExpr<*>>): KApp<KBV8Sort, *> = ctx.mkBV(byteValue)
+
+    override fun <R> accept(visitor: KDeclVisitor<R>): R = visitor.visit(this)
+}
+
+class KBitVec16ExprDecl internal constructor(ctx: KContext, private val shortValue: Short) :
+    KBitVecExprDecl<KBV16Sort>(ctx, shortValue, ctx.mkBv16Sort()) {
+    override fun apply(args: List<KExpr<*>>): KApp<KBV16Sort, *> = ctx.mkBV(shortValue)
+
+    override fun <R> accept(visitor: KDeclVisitor<R>): R = visitor.visit(this)
+}
+
+class KBitVec32ExprDecl internal constructor(ctx: KContext, private val intValue: Int) :
+    KBitVecExprDecl<KBV32Sort>(ctx, intValue, ctx.mkBv32Sort()) {
+    override fun apply(args: List<KExpr<*>>): KApp<KBV32Sort, *> = ctx.mkBV(intValue)
+
+    override fun <R> accept(visitor: KDeclVisitor<R>): R = visitor.visit(this)
+}
+
+class KBitVec64ExprDecl internal constructor(ctx: KContext, private val longValue: Long) :
+    KBitVecExprDecl<KBV64Sort>(ctx, longValue, ctx.mkBv64Sort()) {
+    override fun apply(args: List<KExpr<*>>): KApp<KBV64Sort, *> = ctx.mkBV(longValue)
+
+    override fun <R> accept(visitor: KDeclVisitor<R>): R = visitor.visit(this)
+}
+
+class KBitVecCustomSizeExprDecl internal constructor(
+    ctx: KContext,
+    value: String,
+    sizeBits: UInt
+) : KBitVecExprDecl<KBVSort>(ctx, value, ctx.mkBvSort(sizeBits)) {
+    override fun apply(args: List<KExpr<*>>): KApp<KBVSort, *> = ctx.mkBV(value, sort.sizeBits)
+
+    override fun <R> accept(visitor: KDeclVisitor<R>): R = visitor.visit(this)
+}
+
+private fun Number.toBinary(): String = when (this) {
+    is Byte -> toUByte().toString(radix = 2).padStart(Byte.SIZE_BITS, '0')
+    is Short -> toUShort().toString(radix = 2).padStart(Short.SIZE_BITS, '0')
+    is Int -> toUInt().toString(radix = 2).padStart(Int.SIZE_BITS, '0')
+    is Long -> toULong().toString(radix = 2).padStart(Long.SIZE_BITS, '0')
+    else -> error("Unsupported type for transformation into a binary string: ${this::class.simpleName}")
+}

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KBitVecExpr.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KBitVecExpr.kt
@@ -1,23 +1,74 @@
 package org.ksmt.expr
 
 import org.ksmt.KContext
+import org.ksmt.decl.KDecl
+import org.ksmt.sort.KBV16Sort
+import org.ksmt.sort.KBV32Sort
+import org.ksmt.sort.KBV64Sort
+import org.ksmt.sort.KBV8Sort
 import org.ksmt.sort.KBVSort
 
-interface KBVSize
-object KBVSize8 : KBVSize
-object KBVSize16 : KBVSize
-object KBVSize32 : KBVSize
-object KBVSize64 : KBVSize
-
-class KBVCustomSize(val sizeBits: UInt) : KBVSize
-
-abstract class BitVecExpr<T : KBVSort<KBVSize>>(
-    ctx: KContext,
-    override val args: List<KExpr<*>>
+abstract class KBitVecExpr<T : KBVSort>(
+    ctx: KContext
 ) : KApp<T, KExpr<*>>(ctx) {
-    override fun accept(transformer: KTransformer): KExpr<T> = transformer.transform(this)
+    override val args: List<KExpr<*>> = emptyList()
 }
 
-fun <S : KBVSize> mkBVAdd(lhs: KExpr<KBVSort<S>>, rhs: KExpr<KBVSort<S>>) {
-    TODO()
+abstract class KBitVecNumberExpr<T : KBVSort, N : Number>(
+    ctx: KContext,
+    val numberValue: N
+) : KBitVecExpr<T>(ctx)
+
+class KBitVec8Expr internal constructor(ctx: KContext, byteValue: Byte) :
+    KBitVecNumberExpr<KBV8Sort, Byte>(ctx, byteValue) {
+    override fun accept(transformer: KTransformer): KExpr<KBV8Sort> = transformer.transform(this)
+
+    override fun decl(): KDecl<KBV8Sort> = ctx.mkBvDecl(numberValue)
+
+    override fun sort(): KBV8Sort = ctx.mkBv8Sort()
+}
+
+class KBitVec16Expr internal constructor(ctx: KContext, shortValue: Short) :
+    KBitVecNumberExpr<KBV16Sort, Short>(ctx, shortValue) {
+    override fun accept(transformer: KTransformer): KExpr<KBV16Sort> = transformer.transform(this)
+
+    override fun decl(): KDecl<KBV16Sort> = ctx.mkBvDecl(numberValue)
+
+    override fun sort(): KBV16Sort = ctx.mkBv16Sort()
+}
+
+class KBitVec32Expr internal constructor(ctx: KContext, intValue: Int) :
+    KBitVecNumberExpr<KBV32Sort, Int>(ctx, intValue) {
+    override fun accept(transformer: KTransformer): KExpr<KBV32Sort> = transformer.transform(this)
+
+    override fun decl(): KDecl<KBV32Sort> = ctx.mkBvDecl(numberValue)
+
+    override fun sort(): KBV32Sort = ctx.mkBv32Sort()
+}
+
+class KBitVec64Expr internal constructor(ctx: KContext, longValue: Long) :
+    KBitVecNumberExpr<KBV64Sort, Long>(ctx, longValue) {
+    override fun accept(transformer: KTransformer): KExpr<KBV64Sort> = transformer.transform(this)
+
+    override fun decl(): KDecl<KBV64Sort> = ctx.mkBvDecl(numberValue)
+    override fun sort(): KBV64Sort = ctx.mkBv64Sort()
+}
+
+class KBitVecCustomExpr internal constructor(
+    ctx: KContext,
+    val value: String,
+    private val sizeBits: UInt
+) : KBitVecExpr<KBVSort>(ctx) {
+
+    init {
+        require(value.length.toUInt() == sizeBits) {
+            "Provided string $value consist of ${value.length} symbols, but $sizeBits were expected"
+        }
+    }
+
+    override fun accept(transformer: KTransformer): KExpr<KBVSort> = transformer.transform(this)
+
+    override fun decl(): KDecl<KBVSort> = ctx.mkBvDecl(value, sizeBits)
+
+    override fun sort(): KBVSort = ctx.mkBvSort(sizeBits)
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KTransformer.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KTransformer.kt
@@ -3,6 +3,11 @@ package org.ksmt.expr
 import org.ksmt.KContext
 import org.ksmt.sort.KArraySort
 import org.ksmt.sort.KArithSort
+import org.ksmt.sort.KBV16Sort
+import org.ksmt.sort.KBV32Sort
+import org.ksmt.sort.KBV64Sort
+import org.ksmt.sort.KBV8Sort
+import org.ksmt.sort.KBVCustomSizeSort
 import org.ksmt.sort.KIntSort
 import org.ksmt.sort.KRealSort
 import org.ksmt.sort.KBVSort
@@ -34,7 +39,12 @@ interface KTransformer {
     fun <T : KSort> transform(expr: KIteExpr<T>): KExpr<T> = transformApp(expr)
 
     // bit-vec transformers
-    fun <T : KBVSort<KBVSize>> transform(expr: BitVecExpr<T>): KExpr<T> = transformApp(expr)
+    fun <T: KBVSort> transformBitVecExpr(expr: KBitVecExpr<T>): KExpr<T> = transformApp(expr)
+    fun transform(expr: KBitVec8Expr): KExpr<KBV8Sort> = transformBitVecExpr(expr)
+    fun transform(expr: KBitVec16Expr): KExpr<KBV16Sort> = transformBitVecExpr(expr)
+    fun transform(expr: KBitVec32Expr): KExpr<KBV32Sort> = transformBitVecExpr(expr)
+    fun transform(expr: KBitVec64Expr): KExpr<KBV64Sort> = transformBitVecExpr(expr)
+    fun transform(expr: KBitVecCustomExpr): KExpr<KBVSort> = transformBitVecExpr(expr)
 
     // array transformers
     fun <D : KSort, R : KSort> transform(expr: KArrayStore<D, R>): KExpr<KArraySort<D, R>> = transformApp(expr)

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/model/KModelEvaluator.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/model/KModelEvaluator.kt
@@ -74,6 +74,9 @@ open class KModelEvaluator(override val ctx: KContext, val model: KModel, val co
     }
 
     override fun transformIntNum(expr: KIntNumExpr): KExpr<KIntSort> = expr.evalExpr { expr }
+
+    override fun <T : KBVSort> transformBitVecExpr(expr: KBitVecExpr<T>): KExpr<T> = expr.evalExpr { expr }
+
     override fun transform(expr: KRealNumExpr): KExpr<KRealSort> = expr.evalExpr { expr }
     override fun transform(expr: KTrue): KExpr<KBoolSort> = expr.evalExpr { expr }
     override fun transform(expr: KFalse): KExpr<KBoolSort> = expr.evalExpr { expr }
@@ -135,12 +138,9 @@ open class KModelEvaluator(override val ctx: KContext, val model: KModel, val co
             override fun visit(sort: KBoolSort): KExpr<T> = trueExpr as KExpr<T>
             override fun visit(sort: KIntSort): KExpr<T> = 0.intExpr as KExpr<T>
             override fun visit(sort: KRealSort): KExpr<T> = mkRealNum(0) as KExpr<T>
+            override fun <S : KBVSort> visit(sort: S): KExpr<T> = mkBV(0) as KExpr<T>
             override fun <D : KSort, R : KSort> visit(sort: KArraySort<D, R>): KExpr<T> =
                 mkArrayConst(sort, sort.range.sampleValue()) as KExpr<T>
-
-            override fun <S : KBVSize> visit(sort: KBVSort<S>): KExpr<T> {
-                TODO("Not yet implemented")
-            }
         })
     }
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/sort/KSort.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/sort/KSort.kt
@@ -2,7 +2,6 @@ package org.ksmt.sort
 
 import org.ksmt.KAst
 import org.ksmt.KContext
-import org.ksmt.expr.KBVSize
 
 abstract class KSort(ctx: KContext) : KAst(ctx) {
     abstract fun <T> accept(visitor: KSortVisitor<T>): T
@@ -25,12 +24,41 @@ class KRealSort internal constructor(ctx: KContext) : KArithSort<KRealSort>(ctx)
     override fun print(): String = "Real"
 }
 
-class KBVSort<S : KBVSize> internal constructor(ctx: KContext) : KSort(ctx) {
-    override fun <T> accept(visitor: KSortVisitor<T>): T = visitor.visit(this)
-    override fun print(): String = "BV"
-}
-
 class KArraySort<D : KSort, R : KSort> internal constructor(ctx: KContext, val domain: D, val range: R) : KSort(ctx) {
     override fun <T> accept(visitor: KSortVisitor<T>): T = visitor.visit(this)
     override fun print(): String = "(Array $domain $range)"
+}
+
+abstract class KBVSort(ctx: KContext) : KSort(ctx) {
+    abstract val sizeBits: UInt
+
+    override fun print(): String = "BitVec $sizeBits"
+}
+
+class KBV8Sort internal constructor(ctx: KContext) : KBVSort(ctx) {
+    override val sizeBits: UInt = Byte.SIZE_BITS.toUInt()
+
+    override fun <T> accept(visitor: KSortVisitor<T>): T = visitor.visit(this)
+}
+
+class KBV16Sort internal constructor(ctx: KContext) : KBVSort(ctx) {
+    override val sizeBits: UInt = Short.SIZE_BITS.toUInt()
+
+    override fun <T> accept(visitor: KSortVisitor<T>): T = visitor.visit(this)
+}
+
+class KBV32Sort internal constructor(ctx: KContext) : KBVSort(ctx) {
+    override val sizeBits: UInt = Int.SIZE_BITS.toUInt()
+
+    override fun <T> accept(visitor: KSortVisitor<T>): T = visitor.visit(this)
+}
+
+class KBV64Sort internal constructor(ctx: KContext) : KBVSort(ctx) {
+    override val sizeBits: UInt = Long.SIZE_BITS.toUInt()
+
+    override fun <T> accept(visitor: KSortVisitor<T>): T = visitor.visit(this)
+}
+
+class KBVCustomSizeSort internal constructor(ctx: KContext, override val sizeBits: UInt) : KBVSort(ctx) {
+    override fun <T> accept(visitor: KSortVisitor<T>): T = visitor.visit(this)
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/sort/KSortVisitor.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/sort/KSortVisitor.kt
@@ -1,12 +1,10 @@
 package org.ksmt.sort
 
-import org.ksmt.expr.KBVSize
-
 interface KSortVisitor<T> {
     fun visit(sort: KSort): Any = error("visitor is not implemented for sort $sort")
     fun visit(sort: KBoolSort): T
     fun visit(sort: KIntSort): T
     fun visit(sort: KRealSort): T
-    fun <S : KBVSize> visit(sort: KBVSort<S>): T
+    fun <S: KBVSort> visit(sort: S): T
     fun <D : KSort, R : KSort> visit(sort: KArraySort<D, R>): T
 }

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3SortInternalizer.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3SortInternalizer.kt
@@ -2,7 +2,6 @@ package org.ksmt.solver.z3
 
 import com.microsoft.z3.Context
 import com.microsoft.z3.Sort
-import org.ksmt.expr.KBVSize
 import org.ksmt.sort.KSortVisitor
 import org.ksmt.sort.KIntSort
 import org.ksmt.sort.KRealSort
@@ -33,8 +32,8 @@ open class KZ3SortInternalizer(
             z3Ctx.mkArraySort(sort.domain.internalizeZ3Sort(), sort.range.internalizeZ3Sort())
         }
 
-    override fun <S : KBVSize> visit(sort: KBVSort<S>): Sort {
-        TODO("Not yet implemented")
+    override fun <T : KBVSort> visit(sort: T): Sort = z3InternCtx.internalizeSort(sort) {
+        z3Ctx.mkBitVecSort(sort.sizeBits.toInt())
     }
 
     fun <T : KSort> T.internalizeZ3Sort() = accept(this@KZ3SortInternalizer)


### PR DESCRIPTION
Initial support for BitVectors literals 

Contains only classes declarations, sorts, etc

It is not clear whether it is a good way to represent them, but I didn't find an obvious way how to generalize types for bv with particular length