### PR TITLE
Use custom native library loader for Z3

### DIFF
--- a/ksmt-core/src/main/kotlin/org/ksmt/utils/NativeLibraryLoader.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/utils/NativeLibraryLoader.kt
@@ -1,0 +1,46 @@
+package org.ksmt.utils
+
+import java.nio.file.Files
+import kotlin.io.path.outputStream
+
+object NativeLibraryLoader {
+    enum class OS {
+        LINUX, WINDOWS, MACOS
+    }
+
+    private val supportedArchs = setOf("amd64", "x86_64")
+
+    fun load(libraries: (OS) -> List<String>) {
+        val arch = System.getProperty("os.arch")
+        require(arch in supportedArchs) { "Not supported arch: $arch" }
+
+        val osName = System.getProperty("os.name").lowercase()
+        val (os, libraryExt) = when {
+            osName.startsWith("linux") -> OS.LINUX to ".so"
+            osName.startsWith("windows") -> OS.WINDOWS to ".dll"
+            osName.startsWith("mac") -> OS.MACOS to ".dylib"
+            else -> error("Unknown OS: $osName")
+        }
+
+        val librariesToLoad = libraries(os)
+        for (libName in librariesToLoad) {
+            val osLibName = libName + libraryExt
+            val resourceName = "lib/x64/$osLibName"
+            val libUri = NativeLibraryLoader::class.java.classLoader
+                .getResource(resourceName)?.toURI()
+                ?: error("Can't find native library $osLibName")
+
+            if (libUri.scheme == "file") {
+                System.load(libUri.path)
+                continue
+            }
+
+            val libFile = Files.createTempFile(libName, libraryExt)
+            NativeLibraryLoader::class.java.classLoader
+                .getResourceAsStream(resourceName)?.use { libResourceStream ->
+                    libFile.outputStream().use { libResourceStream.copyTo(it) }
+                }
+            System.load(libFile.toAbsolutePath().toString())
+        }
+    }
+}

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Solver.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Solver.kt
@@ -11,6 +11,7 @@ import org.ksmt.solver.KSolver
 import org.ksmt.solver.KSolverException
 import org.ksmt.solver.KSolverStatus
 import org.ksmt.sort.KBoolSort
+import org.ksmt.utils.NativeLibraryLoader
 
 open class KZ3Solver(private val ctx: KContext) : KSolver {
     private val z3Ctx = Context()
@@ -82,5 +83,18 @@ open class KZ3Solver(private val ctx: KContext) : KSolver {
     override fun close() {
         z3InternCtx.close()
         z3Ctx.close()
+    }
+
+    companion object {
+        init {
+            System.setProperty("z3.skipLibraryLoad", "true")
+            NativeLibraryLoader.load { os ->
+                when (os) {
+                    NativeLibraryLoader.OS.LINUX -> listOf("libz3", "libz3java")
+                    NativeLibraryLoader.OS.MACOS -> listOf("libz3", "libz3java")
+                    NativeLibraryLoader.OS.WINDOWS -> listOf("vcruntime140", "vcruntime140_1", "libz3", "libz3java")
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix Z3 library loader. Currently, library load fails if Z3 library is not installed.