### PR TITLE
Solver incremental api

### DIFF
--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/KSolver.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/KSolver.kt
@@ -2,9 +2,65 @@ package org.ksmt.solver
 
 import org.ksmt.expr.KExpr
 import org.ksmt.sort.KBoolSort
+import kotlin.time.Duration
 
 interface KSolver : AutoCloseable {
+
+    /** Assert an expression into solver.
+     * @see check
+     * */
     fun assert(expr: KExpr<KBoolSort>)
-    fun check(): KSolverStatus
+
+    /** Assert an expression into solver.
+     * @return [KBoolSort] constant which is used to track a given assertion
+     * in unsat cores.
+     * @see checkWithAssumptions
+     * @see unsatCore
+     * */
+    fun assertAndTrack(expr: KExpr<KBoolSort>): KExpr<KBoolSort>
+
+    /** Create a backtracking point for assertion stack.
+     *  @see pop
+     * */
+    fun push()
+
+    /** Revert solver assertions state to previously created backtracking point.
+     *  @param n number of pushed scopes to revert.
+     *  @see push
+     * */
+    fun pop(n: UInt = 1u)
+
+    /** Performs satisfiability check of currently asserted expressions.
+     * @param timeout solver check timeout. When time limit is reached [KSolverStatus.UNKNOWN] is returned.
+     * @return satisfiability check result.
+     * * [KSolverStatus.SAT] assertions are satisfiable. Satisfying assignment can be retrieved via [model].
+     * * [KSolverStatus.UNSAT] assertions are unsatisfiable. Unsat core can be retrieved via [unsatCore].
+     * * [KSolverStatus.UNKNOWN] solver failed to check satisfiability due to timeout or internal reasons.
+     * Brief reason description may be obtained via [reasonOfUnknown].
+     * */
+    fun check(timeout: Duration = Duration.INFINITE): KSolverStatus
+
+    /** Performs satisfiability check of currently asserted expressions and provided assumptions.
+     *
+     * In case of [KSolverStatus.UNSAT] result assumptions are used for unsat core generation.
+     * @see check
+     * @see unsatCore
+     * */
+    fun checkWithAssumptions(assumptions: List<KExpr<KBoolSort>>, timeout: Duration = Duration.INFINITE): KSolverStatus
+
+    /** Retrieve the model for the last [check] or [checkWithAssumptions].
+     * */
     fun model(): KModel
+
+    /** Retrieve the unsat core for the last [check] or [checkWithAssumptions].
+     * Unsat core consists only of:
+     * 1. assumptions provided in [checkWithAssumptions]
+     * 2. track variables corresponding to expressions asserted with [assertAndTrack]
+     * */
+    fun unsatCore(): List<KExpr<KBoolSort>>
+
+    /** Retrieve a brief explanation of an [KSolverStatus.UNKNOWN] result.
+     * The format of resulting string is solver implementation dependent.
+     * */
+    fun reasonOfUnknown(): String
 }

--- a/ksmt-z3/build.gradle.kts
+++ b/ksmt-z3/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     z3native("com.microsoft.z3", "z3-native-osx", "4.8.9.1", ext = "zip")
 }
 
-tasks.withType<KotlinCompile> {
+tasks.getByName<KotlinCompile>("compileKotlin") {
     kotlinOptions.allWarningsAsErrors = true
 }
 

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Solver.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Solver.kt
@@ -2,6 +2,7 @@ package org.ksmt.solver.z3
 
 import com.microsoft.z3.BoolExpr
 import com.microsoft.z3.Context
+import com.microsoft.z3.Solver
 import com.microsoft.z3.Status
 import com.microsoft.z3.Z3Exception
 import org.ksmt.KContext
@@ -12,12 +13,16 @@ import org.ksmt.solver.KSolverException
 import org.ksmt.solver.KSolverStatus
 import org.ksmt.sort.KBoolSort
 import org.ksmt.utils.NativeLibraryLoader
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
 
+@Suppress("TooManyFunctions")
 open class KZ3Solver(private val ctx: KContext) : KSolver {
     private val z3Ctx = Context()
     private val solver = z3Ctx.mkSolver()
     private val z3InternCtx = KZ3InternalizationContext()
     private var lastCheckStatus = KSolverStatus.UNKNOWN
+    private var currentScope: UInt = 0u
     private val sortInternalizer by lazy {
         createSortInternalizer(z3InternCtx, z3Ctx)
     }
@@ -54,35 +59,95 @@ open class KZ3Solver(private val ctx: KContext) : KSolver {
         z3Ctx: Context
     ) = KZ3ExprConverter(ctx, internCtx)
 
-    override fun assert(expr: KExpr<KBoolSort>) = try {
+    override fun push() {
+        solver.push()
+        currentScope++
+    }
+
+    override fun pop(n: UInt) {
+        require(n <= currentScope) {
+            "Can not pop $n scope levels because current scope level is $currentScope"
+        }
+        if (n == 0u) return
+        solver.pop(n.toInt())
+        currentScope -= n
+    }
+
+    override fun assert(expr: KExpr<KBoolSort>) = z3Try {
         val z3Expr = with(exprInternalizer) { expr.internalize() }
         solver.add(z3Expr as BoolExpr)
-    } catch (ex: Z3Exception) {
-        throw KSolverException(ex)
     }
 
-    override fun check(): KSolverStatus = try {
-        val status = solver.check() ?: Status.UNKNOWN
-        when (status) {
-            Status.SATISFIABLE -> KSolverStatus.SAT
-            Status.UNSATISFIABLE -> KSolverStatus.UNSAT
-            Status.UNKNOWN -> KSolverStatus.UNKNOWN
-        }.also { lastCheckStatus = it }
-    } catch (ex: Z3Exception) {
-        throw KSolverException(ex)
+    override fun assertAndTrack(expr: KExpr<KBoolSort>): KExpr<KBoolSort> = z3Try {
+        val z3Expr = with(exprInternalizer) { expr.internalize() } as BoolExpr
+
+        @Suppress("ForbiddenComment") // todo: use our fresh const when available
+        val trackVar = z3Ctx.mkFreshConst("track", z3Ctx.boolSort) as BoolExpr
+
+        solver.assertAndTrack(z3Expr, trackVar)
+        with(exprConverter) { trackVar.convert() }
     }
 
-    override fun model(): KModel = try {
+    override fun check(timeout: Duration): KSolverStatus = z3Try {
+        solver.updateTimeout(timeout)
+        solver.check().processCheckResult()
+    }
+
+    @Suppress("SpreadOperator")
+    override fun checkWithAssumptions(
+        assumptions: List<KExpr<KBoolSort>>,
+        timeout: Duration
+    ): KSolverStatus = z3Try {
+        val z3Assumptions = with(exprInternalizer) { assumptions.map { it.internalize() as BoolExpr } }
+        solver.updateTimeout(timeout)
+        solver.check(*z3Assumptions.toTypedArray()).processCheckResult()
+    }
+
+    override fun model(): KModel = z3Try {
         require(lastCheckStatus == KSolverStatus.SAT) { "Model are only available after SAT checks" }
         val model = solver.model
         KZ3Model(model, ctx, z3InternCtx, exprInternalizer, z3Ctx, exprConverter)
-    } catch (ex: Z3Exception) {
-        throw KSolverException(ex)
+    }
+
+    override fun unsatCore(): List<KExpr<KBoolSort>> = z3Try {
+        require(lastCheckStatus == KSolverStatus.UNSAT) { "Unsat cores are only available after UNSAT checks" }
+        val z3Core = solver.unsatCore
+        with(exprConverter) { z3Core.map { it.convert() } }
+    }
+
+    override fun reasonOfUnknown(): String = z3Try {
+        require(lastCheckStatus == KSolverStatus.UNKNOWN) { "Unknown reason is only available after UNKNOWN checks" }
+        solver.reasonUnknown
     }
 
     override fun close() {
         z3InternCtx.close()
         z3Ctx.close()
+    }
+
+    private fun Status?.processCheckResult() = when (this) {
+        Status.SATISFIABLE -> KSolverStatus.SAT
+        Status.UNSATISFIABLE -> KSolverStatus.UNSAT
+        Status.UNKNOWN -> KSolverStatus.UNKNOWN
+        null -> KSolverStatus.UNKNOWN
+    }.also { lastCheckStatus = it }
+
+    private fun Solver.updateTimeout(timeout: Duration) {
+        val z3Timeout = if (timeout == Duration.INFINITE) {
+            UInt.MAX_VALUE.toInt()
+        } else {
+            timeout.toInt(DurationUnit.MILLISECONDS)
+        }
+        val params = z3Ctx.mkParams().apply {
+            add("timeout", z3Timeout)
+        }
+        setParameters(params)
+    }
+
+    private inline fun <reified T> z3Try(body: () -> T): T = try {
+        body()
+    } catch (ex: Z3Exception) {
+        throw KSolverException(ex)
     }
 
     companion object {

--- a/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/IncrementalApiTest.kt
+++ b/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/IncrementalApiTest.kt
@@ -1,0 +1,88 @@
+package org.ksmt.solver.z3
+
+import org.ksmt.KContext
+import org.ksmt.solver.KSolverStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+
+class IncrementalApiTest {
+    private val ctx = KContext()
+    private val solver = KZ3Solver(ctx)
+
+    @Test
+    fun testUnsatCoreGeneration(): Unit = with(ctx) {
+        val a = boolSort.mkConst("a")
+        val b = boolSort.mkConst("b")
+        val c = boolSort.mkConst("c")
+
+        val e1 = (a and b) or c
+        val e2 = !(a and b)
+        val e3 = !c
+
+        solver.assert(e1)
+        val e2Track = solver.assertAndTrack(e2)
+        val status = solver.checkWithAssumptions(listOf(e3))
+        assertEquals(KSolverStatus.UNSAT, status)
+        val core = solver.unsatCore()
+        assertEquals(2, core.size)
+        assertTrue(e2Track in core)
+        assertTrue(e3 in core)
+    }
+
+    @Test
+    fun testUnsatCoreGenerationNoAssumptions(): Unit = with(ctx) {
+        val a = boolSort.mkConst("a")
+        val b = boolSort.mkConst("b")
+
+        val e1 = (a and b)
+        val e2 = !(a and b)
+
+        solver.assert(e1)
+        val e2Track = solver.assertAndTrack(e2)
+        val status = solver.check()
+        assertEquals(KSolverStatus.UNSAT, status)
+        val core = solver.unsatCore()
+        assertEquals(1, core.size)
+        assertTrue(e2Track in core)
+    }
+
+    @Test
+    fun testPushPop(): Unit = with(ctx) {
+        val a = boolSort.mkConst("a")
+        solver.assert(a)
+        solver.push()
+        val track = solver.assertAndTrack(!a)
+        var status = solver.check()
+        assertEquals(KSolverStatus.UNSAT, status)
+        val core = solver.unsatCore()
+        assertEquals(1, core.size)
+        assertTrue(track in core)
+        solver.pop()
+        status = solver.check()
+        assertEquals(KSolverStatus.SAT, status)
+    }
+
+    @Test
+    fun testTimeout(): Unit = with(ctx) {
+        val array = mkArraySort(intSort, mkArraySort(intSort, intSort)).mkConst("array")
+        val result = mkArraySort(intSort, intSort).mkConst("result")
+
+        val i = intSort.mkConst("i")
+        val j = intSort.mkConst("i")
+        val idx = mkIte((i mod j) eq mkIntNum(100), i, j)
+        val body = result.select(idx) eq array.select(i).select(j)
+        val rule = mkUniversalQuantifier(body, listOf(i.decl, j.decl))
+        solver.assert(rule)
+
+        val x = intSort.mkConst("x")
+        val queryBody = result.select(x) gt result.select(x + mkIntNum(10))
+        val query = mkUniversalQuantifier(queryBody, listOf(x.decl))
+        solver.assert(query)
+
+        val status = solver.checkWithAssumptions(emptyList(), timeout = 1.milliseconds)
+        assertEquals(KSolverStatus.UNKNOWN, status)
+        assertEquals("timeout", solver.reasonOfUnknown())
+    }
+}


### PR DESCRIPTION
Extend solver api with:
1. push/pop operations
2. satisfiability check with assumptions

Also add timeouts to solver checks and provide better solver api docs.