### PR TITLE
Remove KAst.toString cache due to high memory consumption

### DIFF
--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprConverter.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprConverter.kt
@@ -516,7 +516,12 @@ open class KBitwuzlaExprConverter(
 
     private inner class BoolToBv1AdapterExpr(val arg: KExpr<KBoolSort>) : KExpr<KBv1Sort>(ctx) {
         override fun sort(): KBv1Sort = ctx.bv1Sort
-        override fun print(): String = "(toBV1 $arg)"
+
+        override fun print(builder: StringBuilder) {
+            builder.append("(toBV1 ")
+            arg.print(builder)
+            builder.append(')')
+        }
 
         override fun accept(transformer: KTransformer): KExpr<KBv1Sort> =
             (transformer as AdapterTermRewriter).transform(this)
@@ -524,7 +529,12 @@ open class KBitwuzlaExprConverter(
 
     private inner class Bv1ToBoolAdapterExpr(val arg: KExpr<KBv1Sort>) : KExpr<KBoolSort>(ctx) {
         override fun sort(): KBoolSort = ctx.boolSort
-        override fun print(): String = "(toBool $arg)"
+
+        override fun print(builder: StringBuilder) {
+            builder.append("(toBool ")
+            arg.print(builder)
+            builder.append(')')
+        }
 
         override fun accept(transformer: KTransformer): KExpr<KBoolSort> =
             (transformer as AdapterTermRewriter).transform(this)
@@ -536,7 +546,14 @@ open class KBitwuzlaExprConverter(
         val toRangeSort: ToRange
     ) : KExpr<KArraySort<ToDomain, ToRange>>(ctx) {
         override fun sort(): KArraySort<ToDomain, ToRange> = ctx.mkArraySort(toDomainSort, toRangeSort)
-        override fun print(): String = "(toArray ${sort()} $arg)"
+
+        override fun print(builder: StringBuilder) {
+            builder.append("(toArray ")
+            sort().print(builder)
+            builder.append(' ')
+            arg.print(builder)
+            builder.append(')')
+        }
 
         override fun accept(transformer: KTransformer): KExpr<KArraySort<ToDomain, ToRange>> =
             (transformer as AdapterTermRewriter).transform(this)

--- a/ksmt-core/src/main/kotlin/org/ksmt/KAst.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/KAst.kt
@@ -1,6 +1,6 @@
 package org.ksmt
 
 abstract class KAst(val ctx: KContext) {
-    abstract fun print(): String
+    abstract fun print(builder: StringBuilder)
     override fun toString(): String = with(ctx) { stringRepr }
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
@@ -1496,10 +1496,14 @@ open class KContext {
     * KAst
     * */
 
-    // toString cache
-    private val astStringReprCache = mkCache { ast: KAst -> ast.print() }
+    /**
+     * String representations are not cached since
+     * it requires a lot of memory.
+     * For example, (and a b) will store a full copy
+     * of a and b string representations
+     * */
     val KAst.stringRepr: String
-        get() = astStringReprCache.create(this)
+        get() = buildString { print(this) }
 
     // context utils
     private fun ensureContextMatch(vararg args: KAst) {

--- a/ksmt-core/src/main/kotlin/org/ksmt/decl/KFuncDecl.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/decl/KFuncDecl.kt
@@ -18,14 +18,19 @@ open class KFuncDecl<T : KSort>(
 
     override fun <R> accept(visitor: KDeclVisitor<R>): R = visitor.visit(this)
 
-    override fun print(): String = buildString {
+    override fun print(builder: StringBuilder): Unit = with(builder) {
         append('(')
         append(name)
         append(" (")
-        append(argSorts.joinToString(" "))
+
+        for ((i, sort) in argSorts.withIndex()) {
+            if (i > 0) append(" ")
+            sort.print(this)
+        }
+
         append(") ")
-        append("$sort")
-        append(" )")
+        sort.print(this)
+        append(')')
     }
 
     fun checkArgSorts(args: List<KExpr<*>>) = with(ctx) {
@@ -102,14 +107,14 @@ abstract class KFuncDeclChain<T : KSort, A : KSort>(
 ) : KFuncDecl<T>(ctx, name, resultSort, listOf(argSort)) {
     abstract fun KContext.applyChain(args: List<KExpr<A>>): KApp<T, KExpr<A>>
 
-    override fun print(): String = buildString {
-        append('(')
-        append(name)
-        append(" (")
-        append("$argSort *")
-        append(") ")
-        append("$sort")
-        append(" )")
+    override fun print(builder: StringBuilder) {
+        builder.append('(')
+        builder.append(name)
+        builder.append(" (")
+        argSort.print(builder)
+        builder.append(" *) ")
+        sort.print(builder)
+        builder.append(" )")
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/Array.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/Array.kt
@@ -62,7 +62,11 @@ class KFunctionAsArray<D : KSort, R : KSort> internal constructor(
     }
 
     override fun sort(): KArraySort<D, R> = with(ctx) { mkArraySort(domainSort, function.sort) }
-    override fun print(): String = "(asArray ${function.name})"
+    override fun print(builder: StringBuilder): Unit = with(builder) {
+        append("(asArray ")
+        append(function.name)
+        append(')')
+    }
     override fun accept(transformer: KTransformer): KExpr<KArraySort<D, R>> = transformer.transform(this)
 }
 
@@ -76,13 +80,14 @@ class KArrayLambda<D : KSort, R : KSort> internal constructor(
     val body: KExpr<R>
 ) : KExpr<KArraySort<D, R>>(ctx) {
     override fun sort(): KArraySort<D, R> = with(ctx) { mkArraySort(indexVarDecl.sort, body.sort) }
-    override fun print(): String = buildString {
-        append("(lambda")
-        append(" (")
-        append("(${indexVarDecl.name} ${indexVarDecl.sort})")
-        append(") ")
-        append("$body")
-        append(")")
+    override fun print(builder: StringBuilder): Unit = with(builder) {
+        append("(lambda ((")
+        append(indexVarDecl.name)
+        append(' ')
+        indexVarDecl.sort.print(this)
+        append(")) ")
+        body.print(this)
+        append(')')
     }
 
     override fun accept(transformer: KTransformer): KExpr<KArraySort<D, R>> = transformer.transform(this)

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KApp.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KApp.kt
@@ -7,20 +7,20 @@ import org.ksmt.sort.KSort
 abstract class KApp<T : KSort, A : KExpr<*>> internal constructor(ctx: KContext) : KExpr<T>(ctx) {
     abstract val args: List<A>
     abstract fun decl(): KDecl<T>
-    override fun print(): String = buildString {
-        if (args.isEmpty()) {
-            with(ctx) { append(decl.name) }
-            return@buildString
-        }
-        append('(')
-        with(ctx) {
+    override fun print(builder: StringBuilder): Unit = with(ctx) {
+        with(builder) {
+            if (args.isEmpty()) {
+                append(decl.name)
+                return
+            }
+            append('(')
             append(decl.name)
+            for (arg in args) {
+                append(' ')
+                arg.print(this)
+            }
+            append(')')
         }
-        for (arg in args) {
-            append(' ')
-            append("$arg")
-        }
-        append(')')
     }
 }
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KQuantifier.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KQuantifier.kt
@@ -12,14 +12,21 @@ abstract class KQuantifier(
     override fun sort(): KBoolSort = ctx.mkBoolSort()
 
     abstract fun printQuantifierName(): String
-    override fun print(): String = buildString {
-        append("(${printQuantifierName()}")
+    override fun print(builder: StringBuilder): Unit = with(builder) {
         append('(')
+        append(printQuantifierName())
+        append('(')
+
         bounds.forEach { bound ->
-            append("(${bound.name} ${bound.sort})")
+            append('(')
+            append(bound.name)
+            append(' ')
+            bound.sort.print(this)
+            append(')')
         }
+
         append(')')
-        append("$body")
+        body.print(this)
         append(')')
     }
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/sort/KSort.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/sort/KSort.kt
@@ -9,7 +9,9 @@ abstract class KSort(ctx: KContext) : KAst(ctx) {
 
 class KBoolSort internal constructor(ctx: KContext) : KSort(ctx) {
     override fun <T> accept(visitor: KSortVisitor<T>): T = visitor.visit(this)
-    override fun print(): String = "Bool"
+    override fun print(builder: StringBuilder) {
+        builder.append("Bool")
+    }
 }
 
 @Suppress("UnnecessaryAbstractClass")
@@ -17,25 +19,39 @@ abstract class KArithSort<out T : KArithSort<T>>(ctx: KContext) : KSort(ctx)
 
 class KIntSort internal constructor(ctx: KContext) : KArithSort<KIntSort>(ctx) {
     override fun <T> accept(visitor: KSortVisitor<T>): T = visitor.visit(this)
-    override fun print(): String = "Int"
+    override fun print(builder: StringBuilder) {
+        builder.append("Int")
+    }
 }
 
 class KRealSort internal constructor(ctx: KContext) : KArithSort<KRealSort>(ctx) {
     override fun <T> accept(visitor: KSortVisitor<T>): T = visitor.visit(this)
-    override fun print(): String = "Real"
+    override fun print(builder: StringBuilder) {
+        builder.append("Real")
+    }
 }
 
 class KArraySort<out D : KSort, out R : KSort> internal constructor(
     ctx: KContext, val domain: D, val range: R
 ) : KSort(ctx) {
     override fun <T> accept(visitor: KSortVisitor<T>): T = visitor.visit(this)
-    override fun print(): String = "(Array $domain $range)"
+    override fun print(builder: StringBuilder): Unit = with(builder) {
+        append("(Array ")
+        domain.print(this)
+        append(' ')
+        range.print(this)
+        append(')')
+    }
 }
 
 abstract class KBvSort(ctx: KContext) : KSort(ctx) {
     abstract val sizeBits: UInt
 
-    override fun print(): String = "BitVec $sizeBits"
+    override fun print(builder: StringBuilder): Unit = with(builder) {
+        append("(BitVec ")
+        append(sizeBits)
+        append(')')
+    }
 }
 
 class KBv1Sort internal constructor(ctx: KContext) : KBvSort(ctx) {
@@ -75,5 +91,7 @@ class KBvCustomSizeSort internal constructor(ctx: KContext, override val sizeBit
 class KUninterpretedSort internal constructor(val name: String, ctx: KContext) : KSort(ctx) {
     override fun <T> accept(visitor: KSortVisitor<T>): T = visitor.visit(this)
 
-    override fun print(): String = name
+    override fun print(builder: StringBuilder) {
+        builder.append(name)
+    }
 }

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
@@ -225,7 +225,7 @@ open class KZ3ExprInternalizer(
                 check(bits.size == sizeBits) { "bv bits size mismatch" }
                 z3Ctx.mkBvNumeral(bits)
             }
-            else -> error("Unknown bv expression class ${expr::class} in transformation method: ${expr.print()}")
+            else -> error("Unknown bv expression class ${expr::class} in transformation method: $expr")
         }
     }
 


### PR DESCRIPTION
1. Remove cache for KAst string representations because it requires a lot of memory. For example, `(and a b)` will store a full copy of `a` and `b` string representations.
2. Use single `StringBuilder` during string representation construction