### PR TITLE
Fix z3 build

### DIFF
--- a/ksmt-bitwuzla/build.gradle.kts
+++ b/ksmt-bitwuzla/build.gradle.kts
@@ -38,7 +38,7 @@ tasks.withType<ProcessResources> {
     }
 }
 
-val runBenchmarksBasedTests = project.booleanProperty("bitwuzla.runBenchmarksBasedTests") ?: true
+val runBenchmarksBasedTests = project.booleanProperty("bitwuzla.runBenchmarksBasedTests") ?: false
 
 // skip big benchmarks to achieve faster tests build and run time
 val skipBigBenchmarks = project.booleanProperty("bitwuzla.skipBigBenchmarks") ?: true


### PR DESCRIPTION
Currently, `JitPack` fails to build KSMT because of issues with z3 release download.

Build fails if gradle `clean` and `build` tasks are executed in a single command, because gradle doesn't redownload `z3-release`.
