### PR TITLE
Better const creation API

### DIFF
--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprConverter.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprConverter.kt
@@ -21,6 +21,7 @@ import org.ksmt.sort.KBvSort
 import org.ksmt.sort.KFpRoundingModeSort
 import org.ksmt.sort.KFpSort
 import org.ksmt.sort.KSort
+import org.ksmt.utils.mkFreshConst
 
 @Suppress("LargeClass")
 open class KBitwuzlaExprConverter(

--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaSolver.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaSolver.kt
@@ -10,6 +10,7 @@ import org.ksmt.solver.bitwuzla.bindings.BitwuzlaResult
 import org.ksmt.solver.bitwuzla.bindings.BitwuzlaTerm
 import org.ksmt.solver.bitwuzla.bindings.Native
 import org.ksmt.sort.KBoolSort
+import org.ksmt.utils.mkFreshConst
 import kotlin.time.Duration
 
 open class KBitwuzlaSolver(private val ctx: KContext) : KSolver {

--- a/ksmt-bitwuzla/src/test/kotlin/org/ksmt/solver/bitwuzla/ConverterTest.kt
+++ b/ksmt-bitwuzla/src/test/kotlin/org/ksmt/solver/bitwuzla/ConverterTest.kt
@@ -12,6 +12,7 @@ import org.ksmt.solver.bitwuzla.bindings.FilePtrUtils
 import org.ksmt.solver.bitwuzla.bindings.Native
 import org.ksmt.sort.KBv1Sort
 import org.ksmt.sort.KSort
+import org.ksmt.utils.getValue
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/ksmt-bitwuzla/src/test/kotlin/org/ksmt/solver/bitwuzla/Example.kt
+++ b/ksmt-bitwuzla/src/test/kotlin/org/ksmt/solver/bitwuzla/Example.kt
@@ -4,6 +4,7 @@ import org.ksmt.KContext
 import org.ksmt.solver.KSolverStatus
 import org.ksmt.solver.bitwuzla.KBitwuzlaSolver
 import org.ksmt.sort.KArraySort
+import org.ksmt.utils.mkConst
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith

--- a/ksmt-bitwuzla/src/test/kotlin/org/ksmt/solver/bitwuzla/SolverTest.kt
+++ b/ksmt-bitwuzla/src/test/kotlin/org/ksmt/solver/bitwuzla/SolverTest.kt
@@ -6,6 +6,7 @@ import org.ksmt.solver.KSolverStatus
 import org.ksmt.solver.bitwuzla.KBitwuzlaSolver
 import org.ksmt.solver.bitwuzla.bindings.BitwuzlaKind
 import org.ksmt.solver.bitwuzla.bindings.Native
+import org.ksmt.utils.getValue
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith

--- a/ksmt-core/src/main/kotlin/example/Example.kt
+++ b/ksmt-core/src/main/kotlin/example/Example.kt
@@ -3,6 +3,7 @@ package example
 import org.ksmt.KContext
 import org.ksmt.expr.KBitVec8Value
 import org.ksmt.sort.KBv16Sort
+import org.ksmt.utils.mkConst
 
 @Suppress("UNUSED_VARIABLE")
 fun main() = with(KContext()) {
@@ -11,7 +12,7 @@ fun main() = with(KContext()) {
     val c = mkArraySort(intSort, intSort).mkConst("e")
     val x = mkArraySort(intSort, mkArraySort(intSort, intSort)).mkConst("e")
     val e1 = (c.select(b) + (c.store(b, b).select(b) + b) eq c.select(b)) and a or !a
-    val e2 = x.store(b, c).select(b).select(10.intExpr) ge 11.intExpr
+    val e2 = x.store(b, c).select(b).select(10.expr) ge 11.expr
     val z = 3
 
     val bv8 = mkBv(0.toByte())

--- a/ksmt-core/src/main/kotlin/example/Transformer.kt
+++ b/ksmt-core/src/main/kotlin/example/Transformer.kt
@@ -5,6 +5,7 @@ import org.ksmt.expr.KConst
 import org.ksmt.expr.KExpr
 import org.ksmt.expr.transformer.KTransformer
 import org.ksmt.sort.KSort
+import org.ksmt.utils.mkConst
 
 class ConstCollector(override val ctx: KContext) : KTransformer {
     val constants = hashSetOf<KConst<*>>()

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/model/KModelEvaluator.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/model/KModelEvaluator.kt
@@ -183,7 +183,7 @@ open class KModelEvaluator(
     open fun <T : KSort> T.sampleValue(): KExpr<T> = with(ctx) {
         accept(object : KSortVisitor<KExpr<T>> {
             override fun visit(sort: KBoolSort): KExpr<T> = trueExpr as KExpr<T>
-            override fun visit(sort: KIntSort): KExpr<T> = 0.intExpr as KExpr<T>
+            override fun visit(sort: KIntSort): KExpr<T> = 0.expr as KExpr<T>
             override fun visit(sort: KRealSort): KExpr<T> = mkRealNum(0) as KExpr<T>
             override fun <S : KBvSort> visit(sort: S): KExpr<T> = mkBv("0", sort.sizeBits) as KExpr<T>
             override fun <S : KFpSort> visit(sort: S): KExpr<T> = mkFp(0f, sort) as KExpr<T>

--- a/ksmt-core/src/main/kotlin/org/ksmt/utils/ContextUtils.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/utils/ContextUtils.kt
@@ -1,0 +1,18 @@
+package org.ksmt.utils
+
+import org.ksmt.expr.KApp
+import org.ksmt.sort.KSort
+import kotlin.reflect.KProperty
+
+fun <T : KSort> T.mkConst(name: String): KApp<T, *> = ctx.mkConst(name, this)
+
+fun <T : KSort> T.mkFreshConst(name: String): KApp<T, *> = ctx.mkFreshConst(name, this)
+
+inline operator fun <reified T : KSort> T.getValue(
+    thisRef: Any?,
+    property: KProperty<*>
+): KApp<T, *> = mkConst(property.name)
+
+fun <T : KSort> T.mkFreshConstDecl(name: String) = ctx.mkFreshConstDecl(name, this)
+
+fun <T : KSort> T.mkConstDecl(name: String) = ctx.mkConstDecl(name, this)

--- a/ksmt-runner/src/test/kotlin/org/ksmt/solver/runner/IncrementalApiTest.kt
+++ b/ksmt-runner/src/test/kotlin/org/ksmt/solver/runner/IncrementalApiTest.kt
@@ -8,6 +8,7 @@ import org.ksmt.KContext
 import org.ksmt.solver.KSolver
 import org.ksmt.solver.KSolverStatus
 import org.ksmt.solver.z3.KZ3Solver
+import org.ksmt.utils.mkConst
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Model.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Model.kt
@@ -8,6 +8,7 @@ import org.ksmt.expr.KExpr
 import org.ksmt.solver.KModel
 import org.ksmt.solver.model.KModelImpl
 import org.ksmt.sort.KSort
+import org.ksmt.utils.mkFreshConst
 
 open class KZ3Model(
     private val model: Model,

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Solver.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Solver.kt
@@ -13,6 +13,7 @@ import org.ksmt.solver.KSolverException
 import org.ksmt.solver.KSolverStatus
 import org.ksmt.sort.KBoolSort
 import org.ksmt.utils.NativeLibraryLoader
+import org.ksmt.utils.mkFreshConst
 import java.lang.ref.PhantomReference
 import java.lang.ref.ReferenceQueue
 import java.util.IdentityHashMap

--- a/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/BitVecTest.kt
+++ b/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/BitVecTest.kt
@@ -28,6 +28,7 @@ import org.ksmt.sort.KBv1Sort
 import org.ksmt.sort.KBv32Sort
 import org.ksmt.sort.KBv64Sort
 import org.ksmt.sort.KBv8Sort
+import org.ksmt.utils.mkConst
 import org.ksmt.utils.toBinary
 
 class BitVecTest {

--- a/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/Example.kt
+++ b/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/Example.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.ksmt.KContext
 import org.ksmt.solver.KSolverStatus
 import org.ksmt.sort.KArraySort
+import org.ksmt.utils.mkConst
 
 class Example {
 
@@ -22,15 +23,15 @@ class Example {
         solver.assert(a)
         solver.assert(
             mkUniversalQuantifier(
-                !(c gt 0.intExpr and !(c eq 17.intExpr)) or b.apply(listOf(c)), listOf(c.decl)
+                !(c gt 0.expr and !(c eq 17.expr)) or b.apply(listOf(c)), listOf(c.decl)
             )
         )
         solver.assert(
             mkUniversalQuantifier(
-                !(c le 0.intExpr) or !b.apply(listOf(c)), listOf(c.decl)
+                !(c le 0.expr) or !b.apply(listOf(c)), listOf(c.decl)
             )
         )
-        solver.assert(e.select(3.intExpr) ge 0.intExpr)
+        solver.assert(e.select(3.expr) ge 0.expr)
 
         val bvVariable = mkBv32Sort().mkConst("A")
         val bvValue = mkBv(256)

--- a/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/FloatingPointTest.kt
+++ b/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/FloatingPointTest.kt
@@ -31,6 +31,8 @@ import org.ksmt.sort.KFpSort
 import org.ksmt.utils.booleanSignBit
 import org.ksmt.utils.extractExponent
 import org.ksmt.utils.extractSignificand
+import org.ksmt.utils.getValue
+import org.ksmt.utils.mkConst
 
 
 class FloatingPointTest {

--- a/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/IncrementalApiTest.kt
+++ b/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/IncrementalApiTest.kt
@@ -2,6 +2,7 @@ package org.ksmt.solver.z3
 
 import org.ksmt.KContext
 import org.ksmt.solver.KSolverStatus
+import org.ksmt.utils.mkConst
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue


### PR DESCRIPTION
Move utility extension functions from `KContext`

Pros:
Better usage when `with(ctx)` construction us not suitable (e.g. properties initialization):
```kotlin
class C (val ctx: KContext){

    val a by ctx.intSort
    val b = ctx.intSort.mkConst("b")

}
```
Cons:
Explicit imports are required:
```kotlin
import org.ksmt.utils.getValue // to allow by syntax
import org.ksmt.utils.mkConst
```
