### PR TITLE
Expr sort and decl API rework

### DIFF
--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprConverter.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprConverter.kt
@@ -738,7 +738,8 @@ open class KBitwuzlaExprConverter(
     }
 
     private inner class BoolToBv1AdapterExpr(val arg: KExpr<KBoolSort>) : KExpr<KBv1Sort>(ctx) {
-        override fun sort(): KBv1Sort = ctx.bv1Sort
+        override val sort: KBv1Sort
+            get() = ctx.bv1Sort
 
         override fun print(builder: StringBuilder) {
             builder.append("(toBV1 ")
@@ -753,7 +754,8 @@ open class KBitwuzlaExprConverter(
     }
 
     private inner class Bv1ToBoolAdapterExpr(val arg: KExpr<KBv1Sort>) : KExpr<KBoolSort>(ctx) {
-        override fun sort(): KBoolSort = ctx.boolSort
+        override val sort: KBoolSort
+            get() = ctx.boolSort
 
         override fun print(builder: StringBuilder) {
             builder.append("(toBool ")
@@ -772,11 +774,12 @@ open class KBitwuzlaExprConverter(
         val toDomainSort: ToDomain,
         val toRangeSort: ToRange
     ) : KExpr<KArraySort<ToDomain, ToRange>>(ctx) {
-        override fun sort(): KArraySort<ToDomain, ToRange> = ctx.mkArraySort(toDomainSort, toRangeSort)
+        override val sort: KArraySort<ToDomain, ToRange>
+            get() = ctx.mkArraySort(toDomainSort, toRangeSort)
 
         override fun print(builder: StringBuilder) {
             builder.append("(toArray ")
-            sort().print(builder)
+            sort.print(builder)
             builder.append(' ')
             arg.print(builder)
             builder.append(')')

--- a/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
@@ -1902,12 +1902,13 @@ open class KContext : AutoCloseable {
         return expr.computeExprSort()
     }
 
+    /**
+     * Compute expression sort using cache.
+     * Useful for non-recursive sort computation of deeply nested expressions.
+     * See [KExpr.computeExprSort].
+     * */
     fun <T : KSort> getExprSort(expr: KExpr<T>): T =
         exprSortCache.createIfContextActive(expr).uncheckedCast()
-
-    private val exprDeclCache = mkClosableCache { expr: KApp<*, *> -> with(expr) { decl() } }
-    val <T : KSort> KApp<T, *>.decl: KDecl<T>
-        get() = exprDeclCache.createIfContextActive(this).uncheckedCast()
 
     /*
     * declarations

--- a/ksmt-core/src/main/kotlin/org/ksmt/cache/Cache.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/cache/Cache.kt
@@ -26,6 +26,8 @@ class Cache1<T, A0>(val builder: (A0) -> T) : AutoCloseable {
 
     fun create(a0: A0): T = cache.getOrPut(a0) { builder(a0) }
 
+    operator fun contains(key: A0): Boolean = key in cache
+
     override fun close() {
         cache.clear()
     }

--- a/ksmt-core/src/main/kotlin/org/ksmt/decl/KBitVecExprsDecl.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/decl/KBitVecExprsDecl.kt
@@ -479,7 +479,7 @@ class KBvExtractDecl internal constructor(
     ctx,
     name = "extract",
     resultSort = ctx.mkBvSort((high - low + 1).toUInt()),
-    value.sort(),
+    value.sort,
 ), KParameterizedFuncDecl {
     override fun <R> accept(visitor: KDeclVisitor<R>): R = visitor.visit(this)
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/Arith.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/Arith.kt
@@ -23,7 +23,8 @@ class KAddArithExpr<T : KArithSort<T>> internal constructor(
         require(args.isNotEmpty()) { "add requires at least a single argument" }
     }
 
-    override fun decl(): KArithAddDecl<T> = with(ctx) { mkArithAddDecl(sort) }
+    override val decl: KArithAddDecl<T>
+        get() = ctx.mkArithAddDecl(sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<T> = transformer.transform(this)
 
@@ -45,7 +46,8 @@ class KMulArithExpr<T : KArithSort<T>> internal constructor(
         require(args.isNotEmpty()) { "mul requires at least a single argument" }
     }
 
-    override fun decl(): KArithMulDecl<T> = with(ctx) { mkArithMulDecl(sort) }
+    override val decl: KArithMulDecl<T>
+        get() = ctx.mkArithMulDecl(sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<T> = transformer.transform(this)
 
@@ -67,7 +69,8 @@ class KSubArithExpr<T : KArithSort<T>> internal constructor(
         require(args.isNotEmpty()) { "sub requires at least a single argument" }
     }
 
-    override fun decl(): KArithSubDecl<T> = with(ctx) { mkArithSubDecl(sort) }
+    override val decl: KArithSubDecl<T>
+        get() = ctx.mkArithSubDecl(sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<T> = transformer.transform(this)
 
@@ -86,7 +89,8 @@ class KUnaryMinusArithExpr<T : KArithSort<T>> internal constructor(
     val arg: KExpr<T>
 ) : KApp<T, KExpr<T>>(ctx) {
 
-    override fun decl(): KArithUnaryMinusDecl<T> = with(ctx) { mkArithUnaryMinusDecl(sort) }
+    override val decl: KArithUnaryMinusDecl<T>
+        get() = ctx.mkArithUnaryMinusDecl(sort)
 
     override val args: List<KExpr<T>>
         get() = listOf(arg)
@@ -109,7 +113,8 @@ class KDivArithExpr<T : KArithSort<T>> internal constructor(
     val rhs: KExpr<T>
 ) : KApp<T, KExpr<T>>(ctx) {
 
-    override fun decl(): KArithDivDecl<T> = with(ctx) { mkArithDivDecl(sort) }
+    override val decl: KArithDivDecl<T>
+        get() = ctx.mkArithDivDecl(sort)
 
     override val args: List<KExpr<T>>
         get() = listOf(lhs, rhs)
@@ -132,7 +137,8 @@ class KPowerArithExpr<T : KArithSort<T>> internal constructor(
     val rhs: KExpr<T>
 ) : KApp<T, KExpr<T>>(ctx) {
 
-    override fun decl(): KArithPowerDecl<T> = with(ctx) { mkArithPowerDecl(sort) }
+    override val decl: KArithPowerDecl<T>
+        get() = ctx.mkArithPowerDecl(sort)
 
     override val args: List<KExpr<T>>
         get() = listOf(lhs, rhs)
@@ -157,7 +163,8 @@ class KLtArithExpr<T : KArithSort<T>> internal constructor(
     override val sort: KBoolSort
         get() = ctx.boolSort
 
-    override fun decl(): KArithLtDecl<T> = with(ctx) { mkArithLtDecl(lhs.sort) }
+    override val decl: KArithLtDecl<T>
+        get() = ctx.mkArithLtDecl(lhs.sort)
 
     override val args: List<KExpr<T>>
         get() = listOf(lhs, rhs)
@@ -173,7 +180,8 @@ class KLeArithExpr<T : KArithSort<T>> internal constructor(
     override val sort: KBoolSort
         get() = ctx.boolSort
 
-    override fun decl(): KArithLeDecl<T> = with(ctx) { mkArithLeDecl(lhs.sort) }
+    override val decl: KArithLeDecl<T>
+        get() = ctx.mkArithLeDecl(lhs.sort)
 
     override val args: List<KExpr<T>>
         get() = listOf(lhs, rhs)
@@ -189,7 +197,8 @@ class KGtArithExpr<T : KArithSort<T>> internal constructor(
     override val sort: KBoolSort
         get() = ctx.boolSort
 
-    override fun decl(): KArithGtDecl<T> = with(ctx) { mkArithGtDecl(lhs.sort) }
+    override val decl: KArithGtDecl<T>
+        get() = ctx.mkArithGtDecl(lhs.sort)
 
     override val args: List<KExpr<T>>
         get() = listOf(lhs, rhs)
@@ -205,7 +214,8 @@ class KGeArithExpr<T : KArithSort<T>> internal constructor(
     override val sort: KBoolSort
         get() = ctx.boolSort
 
-    override fun decl(): KArithGeDecl<T> = with(ctx) { mkArithGeDecl(lhs.sort) }
+    override val decl: KArithGeDecl<T>
+        get() = ctx.mkArithGeDecl(lhs.sort)
 
     override val args: List<KExpr<T>>
         get() = listOf(lhs, rhs)

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/Arith.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/Arith.kt
@@ -23,11 +23,18 @@ class KAddArithExpr<T : KArithSort<T>> internal constructor(
         require(args.isNotEmpty()) { "add requires at least a single argument" }
     }
 
-    override fun sort(): T = with(ctx) { args.first().sort }
-
     override fun decl(): KArithAddDecl<T> = with(ctx) { mkArithAddDecl(sort) }
 
     override fun accept(transformer: KTransformerBase): KExpr<T> = transformer.transform(this)
+
+    override val sort: T
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): T = args.first().sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += args.first()
+    }
 }
 
 class KMulArithExpr<T : KArithSort<T>> internal constructor(
@@ -38,11 +45,18 @@ class KMulArithExpr<T : KArithSort<T>> internal constructor(
         require(args.isNotEmpty()) { "mul requires at least a single argument" }
     }
 
-    override fun sort(): T = with(ctx) { args.first().sort }
-
     override fun decl(): KArithMulDecl<T> = with(ctx) { mkArithMulDecl(sort) }
 
     override fun accept(transformer: KTransformerBase): KExpr<T> = transformer.transform(this)
+
+    override val sort: T
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): T = args.first().sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += args.first()
+    }
 }
 
 class KSubArithExpr<T : KArithSort<T>> internal constructor(
@@ -53,18 +67,24 @@ class KSubArithExpr<T : KArithSort<T>> internal constructor(
         require(args.isNotEmpty()) { "sub requires at least a single argument" }
     }
 
-    override fun sort(): T = with(ctx) { args.first().sort }
-
     override fun decl(): KArithSubDecl<T> = with(ctx) { mkArithSubDecl(sort) }
 
     override fun accept(transformer: KTransformerBase): KExpr<T> = transformer.transform(this)
+
+    override val sort: T
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): T = args.first().sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += args.first()
+    }
 }
 
 class KUnaryMinusArithExpr<T : KArithSort<T>> internal constructor(
     ctx: KContext,
     val arg: KExpr<T>
 ) : KApp<T, KExpr<T>>(ctx) {
-    override fun sort(): T = with(ctx) { arg.sort }
 
     override fun decl(): KArithUnaryMinusDecl<T> = with(ctx) { mkArithUnaryMinusDecl(sort) }
 
@@ -72,6 +92,15 @@ class KUnaryMinusArithExpr<T : KArithSort<T>> internal constructor(
         get() = listOf(arg)
 
     override fun accept(transformer: KTransformerBase): KExpr<T> = transformer.transform(this)
+
+    override val sort: T
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): T = arg.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg
+    }
 }
 
 class KDivArithExpr<T : KArithSort<T>> internal constructor(
@@ -79,7 +108,6 @@ class KDivArithExpr<T : KArithSort<T>> internal constructor(
     val lhs: KExpr<T>,
     val rhs: KExpr<T>
 ) : KApp<T, KExpr<T>>(ctx) {
-    override fun sort(): T = with(ctx) { lhs.sort }
 
     override fun decl(): KArithDivDecl<T> = with(ctx) { mkArithDivDecl(sort) }
 
@@ -87,6 +115,15 @@ class KDivArithExpr<T : KArithSort<T>> internal constructor(
         get() = listOf(lhs, rhs)
 
     override fun accept(transformer: KTransformerBase): KExpr<T> = transformer.transform(this)
+
+    override val sort: T
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): T = lhs.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += lhs
+    }
 }
 
 class KPowerArithExpr<T : KArithSort<T>> internal constructor(
@@ -94,7 +131,6 @@ class KPowerArithExpr<T : KArithSort<T>> internal constructor(
     val lhs: KExpr<T>,
     val rhs: KExpr<T>
 ) : KApp<T, KExpr<T>>(ctx) {
-    override fun sort(): T = with(ctx) { lhs.sort }
 
     override fun decl(): KArithPowerDecl<T> = with(ctx) { mkArithPowerDecl(sort) }
 
@@ -102,6 +138,15 @@ class KPowerArithExpr<T : KArithSort<T>> internal constructor(
         get() = listOf(lhs, rhs)
 
     override fun accept(transformer: KTransformerBase): KExpr<T> = transformer.transform(this)
+
+    override val sort: T
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): T = lhs.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += lhs
+    }
 }
 
 class KLtArithExpr<T : KArithSort<T>> internal constructor(
@@ -109,7 +154,8 @@ class KLtArithExpr<T : KArithSort<T>> internal constructor(
     val lhs: KExpr<T>,
     val rhs: KExpr<T>
 ) : KApp<KBoolSort, KExpr<T>>(ctx) {
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun decl(): KArithLtDecl<T> = with(ctx) { mkArithLtDecl(lhs.sort) }
 
@@ -124,7 +170,8 @@ class KLeArithExpr<T : KArithSort<T>> internal constructor(
     val lhs: KExpr<T>,
     val rhs: KExpr<T>
 ) : KApp<KBoolSort, KExpr<T>>(ctx) {
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun decl(): KArithLeDecl<T> = with(ctx) { mkArithLeDecl(lhs.sort) }
 
@@ -139,7 +186,8 @@ class KGtArithExpr<T : KArithSort<T>> internal constructor(
     val lhs: KExpr<T>,
     val rhs: KExpr<T>
 ) : KApp<KBoolSort, KExpr<T>>(ctx) {
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun decl(): KArithGtDecl<T> = with(ctx) { mkArithGtDecl(lhs.sort) }
 
@@ -154,7 +202,8 @@ class KGeArithExpr<T : KArithSort<T>> internal constructor(
     val lhs: KExpr<T>,
     val rhs: KExpr<T>
 ) : KApp<KBoolSort, KExpr<T>>(ctx) {
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun decl(): KArithGeDecl<T> = with(ctx) { mkArithGeDecl(lhs.sort) }
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/Array.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/Array.kt
@@ -15,7 +15,8 @@ class KArrayStore<D : KSort, R : KSort> internal constructor(
     val value: KExpr<R>
 ) : KApp<KArraySort<D, R>, KExpr<*>>(ctx) {
 
-    override fun decl(): KDecl<KArraySort<D, R>> = with(ctx) { mkArrayStoreDecl(array.sort) }
+    override val decl: KDecl<KArraySort<D, R>>
+        get() = ctx.mkArrayStoreDecl(array.sort)
 
     override val args: List<KExpr<*>>
         get() = listOf(array, index, value)
@@ -37,7 +38,9 @@ class KArraySelect<D : KSort, R : KSort> internal constructor(
     val array: KExpr<KArraySort<D, R>>,
     val index: KExpr<D>
 ) : KApp<R, KExpr<*>>(ctx) {
-    override fun decl(): KDecl<R> = with(ctx) { mkArraySelectDecl(array.sort) }
+
+    override val decl: KDecl<R>
+        get() = ctx.mkArraySelectDecl(array.sort)
 
     override val args: List<KExpr<*>>
         get() = listOf(array, index)
@@ -60,7 +63,8 @@ class KArrayConst<D : KSort, R : KSort> internal constructor(
     val value: KExpr<R>
 ) : KApp<KArraySort<D, R>, KExpr<R>>(ctx) {
 
-    override fun decl(): KArrayConstDecl<D, R> = ctx.mkArrayConstDecl(sort)
+    override val decl: KArrayConstDecl<D, R>
+        get() = ctx.mkArrayConstDecl(sort)
 
     override val args: List<KExpr<R>>
         get() = listOf(value)

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/Array.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/Array.kt
@@ -14,7 +14,6 @@ class KArrayStore<D : KSort, R : KSort> internal constructor(
     val index: KExpr<D>,
     val value: KExpr<R>
 ) : KApp<KArraySort<D, R>, KExpr<*>>(ctx) {
-    override fun sort(): KArraySort<D, R> = with(ctx) { array.sort }
 
     override fun decl(): KDecl<KArraySort<D, R>> = with(ctx) { mkArrayStoreDecl(array.sort) }
 
@@ -22,6 +21,15 @@ class KArrayStore<D : KSort, R : KSort> internal constructor(
         get() = listOf(array, index, value)
 
     override fun accept(transformer: KTransformerBase): KExpr<KArraySort<D, R>> = transformer.transform(this)
+
+    override val sort: KArraySort<D, R>
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): KArraySort<D, R> = array.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += array
+    }
 }
 
 class KArraySelect<D : KSort, R : KSort> internal constructor(
@@ -29,22 +37,28 @@ class KArraySelect<D : KSort, R : KSort> internal constructor(
     val array: KExpr<KArraySort<D, R>>,
     val index: KExpr<D>
 ) : KApp<R, KExpr<*>>(ctx) {
-    override fun sort(): R = with(ctx) { array.sort.range }
-
     override fun decl(): KDecl<R> = with(ctx) { mkArraySelectDecl(array.sort) }
 
     override val args: List<KExpr<*>>
         get() = listOf(array, index)
 
     override fun accept(transformer: KTransformerBase): KExpr<R> = transformer.transform(this)
+
+    override val sort: R
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): R = array.sort.range
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += array
+    }
 }
 
 class KArrayConst<D : KSort, R : KSort> internal constructor(
     ctx: KContext,
-    val sort: KArraySort<D, R>,
+    override val sort: KArraySort<D, R>,
     val value: KExpr<R>
 ) : KApp<KArraySort<D, R>, KExpr<R>>(ctx) {
-    override fun sort(): KArraySort<D, R> = sort
 
     override fun decl(): KArrayConstDecl<D, R> = ctx.mkArrayConstDecl(sort)
 
@@ -68,7 +82,8 @@ class KFunctionAsArray<D : KSort, R : KSort> internal constructor(
         domainSort = function.argSorts.single() as D
     }
 
-    override fun sort(): KArraySort<D, R> = with(ctx) { mkArraySort(domainSort, function.sort) }
+    override val sort: KArraySort<D, R>
+        get() = ctx.mkArraySort(domainSort, function.sort)
 
     override fun print(builder: StringBuilder): Unit = with(builder) {
         append("(asArray ")
@@ -88,7 +103,6 @@ class KArrayLambda<D : KSort, R : KSort> internal constructor(
     val indexVarDecl: KDecl<D>,
     val body: KExpr<R>
 ) : KExpr<KArraySort<D, R>>(ctx) {
-    override fun sort(): KArraySort<D, R> = with(ctx) { mkArraySort(indexVarDecl.sort, body.sort) }
 
     override fun print(builder: StringBuilder): Unit = with(builder) {
         append("(lambda ((")
@@ -104,4 +118,13 @@ class KArrayLambda<D : KSort, R : KSort> internal constructor(
     }
 
     override fun accept(transformer: KTransformerBase): KExpr<KArraySort<D, R>> = transformer.transform(this)
+
+    override val sort: KArraySort<D, R>
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): KArraySort<D, R> = ctx.mkArraySort(indexVarDecl.sort, body.sort)
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += body
+    }
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/Bool.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/Bool.kt
@@ -19,7 +19,8 @@ class KAndExpr internal constructor(
     ctx: KContext,
     override val args: List<KExpr<KBoolSort>>
 ) : KApp<KBoolSort, KExpr<KBoolSort>>(ctx) {
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun decl(): KAndDecl = ctx.mkAndDecl()
 
@@ -30,7 +31,8 @@ class KOrExpr internal constructor(
     ctx: KContext,
     override val args: List<KExpr<KBoolSort>>
 ) : KApp<KBoolSort, KExpr<KBoolSort>>(ctx) {
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun decl(): KOrDecl = ctx.mkOrDecl()
 
@@ -41,7 +43,8 @@ class KNotExpr internal constructor(
     ctx: KContext,
     val arg: KExpr<KBoolSort>
 ) : KApp<KBoolSort, KExpr<KBoolSort>>(ctx) {
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun decl(): KNotDecl = ctx.mkNotDecl()
 
@@ -56,7 +59,8 @@ class KImpliesExpr internal constructor(
     val p: KExpr<KBoolSort>,
     val q: KExpr<KBoolSort>
 ) : KApp<KBoolSort, KExpr<KBoolSort>>(ctx) {
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun decl(): KImpliesDecl = ctx.mkImpliesDecl()
 
@@ -71,7 +75,8 @@ class KXorExpr internal constructor(
     val a: KExpr<KBoolSort>,
     val b: KExpr<KBoolSort>
 ) : KApp<KBoolSort, KExpr<KBoolSort>>(ctx) {
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun decl(): KXorDecl = ctx.mkXorDecl()
 
@@ -85,7 +90,8 @@ class KEqExpr<T : KSort> internal constructor(
     ctx: KContext,
     val lhs: KExpr<T>, val rhs: KExpr<T>
 ) : KApp<KBoolSort, KExpr<T>>(ctx) {
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun decl(): KEqDecl<T> = with(ctx) { mkEqDecl(lhs.sort) }
 
@@ -103,7 +109,8 @@ class KDistinctExpr<T : KSort> internal constructor(
         require(args.isNotEmpty()) { "distinct requires at least a single argument" }
     }
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun decl(): KDistinctDecl<T> = with(ctx) { mkDistinctDecl(args.first().sort) }
 
@@ -116,7 +123,6 @@ class KIteExpr<T : KSort> internal constructor(
     val trueBranch: KExpr<T>,
     val falseBranch: KExpr<T>
 ) : KApp<T, KExpr<*>>(ctx) {
-    override fun sort(): T = with(ctx) { trueBranch.sort }
 
     override fun decl(): KIteDecl<T> = with(ctx) { mkIteDecl(trueBranch.sort) }
 
@@ -124,10 +130,20 @@ class KIteExpr<T : KSort> internal constructor(
         get() = listOf(condition, trueBranch, falseBranch)
 
     override fun accept(transformer: KTransformerBase): KExpr<T> = transformer.transform(this)
+
+    override val sort: T
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): T = trueBranch.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += trueBranch
+    }
 }
 
 class KTrue(ctx: KContext) : KApp<KBoolSort, KExpr<*>>(ctx) {
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun decl(): KTrueDecl = ctx.mkTrueDecl()
 
@@ -137,7 +153,8 @@ class KTrue(ctx: KContext) : KApp<KBoolSort, KExpr<*>>(ctx) {
 }
 
 class KFalse(ctx: KContext) : KApp<KBoolSort, KExpr<*>>(ctx) {
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun decl(): KFalseDecl = ctx.mkFalseDecl()
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/Bool.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/Bool.kt
@@ -22,7 +22,8 @@ class KAndExpr internal constructor(
     override val sort: KBoolSort
         get() = ctx.boolSort
 
-    override fun decl(): KAndDecl = ctx.mkAndDecl()
+    override val decl: KAndDecl
+        get() = ctx.mkAndDecl()
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -34,7 +35,8 @@ class KOrExpr internal constructor(
     override val sort: KBoolSort
         get() = ctx.boolSort
 
-    override fun decl(): KOrDecl = ctx.mkOrDecl()
+    override val decl: KOrDecl
+        get() = ctx.mkOrDecl()
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -46,7 +48,8 @@ class KNotExpr internal constructor(
     override val sort: KBoolSort
         get() = ctx.boolSort
 
-    override fun decl(): KNotDecl = ctx.mkNotDecl()
+    override val decl: KNotDecl
+        get() = ctx.mkNotDecl()
 
     override val args: List<KExpr<KBoolSort>>
         get() = listOf(arg)
@@ -62,7 +65,8 @@ class KImpliesExpr internal constructor(
     override val sort: KBoolSort
         get() = ctx.boolSort
 
-    override fun decl(): KImpliesDecl = ctx.mkImpliesDecl()
+    override val decl: KImpliesDecl
+        get() = ctx.mkImpliesDecl()
 
     override val args: List<KExpr<KBoolSort>>
         get() = listOf(p, q)
@@ -78,7 +82,8 @@ class KXorExpr internal constructor(
     override val sort: KBoolSort
         get() = ctx.boolSort
 
-    override fun decl(): KXorDecl = ctx.mkXorDecl()
+    override val decl: KXorDecl
+        get() = ctx.mkXorDecl()
 
     override val args: List<KExpr<KBoolSort>>
         get() = listOf(a, b)
@@ -93,7 +98,8 @@ class KEqExpr<T : KSort> internal constructor(
     override val sort: KBoolSort
         get() = ctx.boolSort
 
-    override fun decl(): KEqDecl<T> = with(ctx) { mkEqDecl(lhs.sort) }
+    override val decl: KEqDecl<T>
+        get() = with(ctx) { mkEqDecl(lhs.sort) }
 
     override val args: List<KExpr<T>>
         get() = listOf(lhs, rhs)
@@ -112,7 +118,8 @@ class KDistinctExpr<T : KSort> internal constructor(
     override val sort: KBoolSort
         get() = ctx.boolSort
 
-    override fun decl(): KDistinctDecl<T> = with(ctx) { mkDistinctDecl(args.first().sort) }
+    override val decl: KDistinctDecl<T>
+        get() = with(ctx) { mkDistinctDecl(args.first().sort) }
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -124,7 +131,8 @@ class KIteExpr<T : KSort> internal constructor(
     val falseBranch: KExpr<T>
 ) : KApp<T, KExpr<*>>(ctx) {
 
-    override fun decl(): KIteDecl<T> = with(ctx) { mkIteDecl(trueBranch.sort) }
+    override val decl: KIteDecl<T>
+        get() = ctx.mkIteDecl(trueBranch.sort)
 
     override val args: List<KExpr<*>>
         get() = listOf(condition, trueBranch, falseBranch)
@@ -145,7 +153,8 @@ class KTrue(ctx: KContext) : KApp<KBoolSort, KExpr<*>>(ctx) {
     override val sort: KBoolSort
         get() = ctx.boolSort
 
-    override fun decl(): KTrueDecl = ctx.mkTrueDecl()
+    override val decl: KTrueDecl
+        get() = ctx.mkTrueDecl()
 
     override val args = emptyList<KExpr<*>>()
 
@@ -156,7 +165,8 @@ class KFalse(ctx: KContext) : KApp<KBoolSort, KExpr<*>>(ctx) {
     override val sort: KBoolSort
         get() = ctx.boolSort
 
-    override fun decl(): KFalseDecl = ctx.mkFalseDecl()
+    override val decl: KFalseDecl
+        get() = ctx.mkFalseDecl()
 
     override val args = emptyList<KExpr<*>>()
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/Integer.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/Integer.kt
@@ -18,7 +18,8 @@ class KModIntExpr internal constructor(
     override val sort: KIntSort
         get() = ctx.intSort
 
-    override fun decl(): KIntModDecl = ctx.mkIntModDecl()
+    override val decl: KIntModDecl
+        get() = ctx.mkIntModDecl()
 
     override val args: List<KExpr<KIntSort>>
         get() = listOf(lhs, rhs)
@@ -34,7 +35,8 @@ class KRemIntExpr internal constructor(
     override val sort: KIntSort
         get() = ctx.intSort
 
-    override fun decl(): KIntRemDecl = ctx.mkIntRemDecl()
+    override val decl: KIntRemDecl
+        get() = ctx.mkIntRemDecl()
 
     override val args: List<KExpr<KIntSort>>
         get() = listOf(lhs, rhs)
@@ -49,7 +51,8 @@ class KToRealIntExpr internal constructor(
     override val sort: KRealSort
         get() = ctx.realSort
 
-    override fun decl(): KIntToRealDecl = ctx.mkIntToRealDecl()
+    override val decl: KIntToRealDecl
+        get() = ctx.mkIntToRealDecl()
 
     override val args: List<KExpr<KIntSort>>
         get() = listOf(arg)
@@ -64,7 +67,8 @@ abstract class KIntNumExpr(
     override val sort: KIntSort
         get() = ctx.intSort
 
-    override fun decl(): KIntNumDecl = ctx.mkIntNumDecl("$value")
+    override val decl: KIntNumDecl
+        get() = ctx.mkIntNumDecl("$value")
 
     override val args = emptyList<KExpr<*>>()
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/Integer.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/Integer.kt
@@ -15,7 +15,8 @@ class KModIntExpr internal constructor(
     val lhs: KExpr<KIntSort>,
     val rhs: KExpr<KIntSort>
 ) : KApp<KIntSort, KExpr<KIntSort>>(ctx) {
-    override fun sort(): KIntSort = ctx.mkIntSort()
+    override val sort: KIntSort
+        get() = ctx.intSort
 
     override fun decl(): KIntModDecl = ctx.mkIntModDecl()
 
@@ -30,7 +31,8 @@ class KRemIntExpr internal constructor(
     val lhs: KExpr<KIntSort>,
     val rhs: KExpr<KIntSort>
 ) : KApp<KIntSort, KExpr<KIntSort>>(ctx) {
-    override fun sort(): KIntSort = ctx.mkIntSort()
+    override val sort: KIntSort
+        get() = ctx.intSort
 
     override fun decl(): KIntRemDecl = ctx.mkIntRemDecl()
 
@@ -44,7 +46,8 @@ class KToRealIntExpr internal constructor(
     ctx: KContext,
     val arg: KExpr<KIntSort>
 ) : KApp<KRealSort, KExpr<KIntSort>>(ctx) {
-    override fun sort(): KRealSort = ctx.mkRealSort()
+    override val sort: KRealSort
+        get() = ctx.realSort
 
     override fun decl(): KIntToRealDecl = ctx.mkIntToRealDecl()
 
@@ -58,7 +61,8 @@ abstract class KIntNumExpr(
     ctx: KContext,
     private val value: Number
 ) : KApp<KIntSort, KExpr<*>>(ctx) {
-    override fun sort(): KIntSort = ctx.mkIntSort()
+    override val sort: KIntSort
+        get() = ctx.intSort
 
     override fun decl(): KIntNumDecl = ctx.mkIntNumDecl("$value")
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KApp.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KApp.kt
@@ -6,9 +6,13 @@ import org.ksmt.expr.transformer.KTransformerBase
 import org.ksmt.sort.KSort
 
 abstract class KApp<T : KSort, A : KExpr<*>> internal constructor(ctx: KContext) : KExpr<T>(ctx) {
+
     abstract val args: List<A>
 
-    abstract fun decl(): KDecl<T>
+    abstract val decl: KDecl<T>
+
+    @Deprecated("Use property", ReplaceWith("decl"))
+    fun decl(): KDecl<T> = decl
 
     override fun print(builder: StringBuilder): Unit = with(ctx) {
         with(builder) {
@@ -32,13 +36,11 @@ abstract class KApp<T : KSort, A : KExpr<*>> internal constructor(ctx: KContext)
 
 open class KFunctionApp<T : KSort> internal constructor(
     ctx: KContext,
-    val decl: KDecl<T>,
+    override val decl: KDecl<T>,
     override val args: List<KExpr<*>>
 ) : KApp<T, KExpr<*>>(ctx) {
     override val sort: T
         get() = decl.sort
-
-    override fun decl(): KDecl<T> = decl
 
     override fun accept(transformer: KTransformerBase): KExpr<T> = transformer.transform(this)
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KApp.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KApp.kt
@@ -35,7 +35,8 @@ open class KFunctionApp<T : KSort> internal constructor(
     val decl: KDecl<T>,
     override val args: List<KExpr<*>>
 ) : KApp<T, KExpr<*>>(ctx) {
-    override fun sort(): T = decl.sort
+    override val sort: T
+        get() = decl.sort
 
     override fun decl(): KDecl<T> = decl
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KBitVecExprs.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KBitVecExprs.kt
@@ -31,7 +31,8 @@ class KBitVec1Value internal constructor(
 
     override fun decl(): KDecl<KBv1Sort> = ctx.mkBvDecl(value)
 
-    override fun sort(): KBv1Sort = ctx.mkBv1Sort()
+    override val sort: KBv1Sort
+        get() = ctx.bv1Sort
 }
 
 abstract class KBitVecNumberValue<S : KBvSort, N : Number>(
@@ -49,7 +50,8 @@ class KBitVec8Value internal constructor(
 
     override fun decl(): KDecl<KBv8Sort> = ctx.mkBvDecl(numberValue)
 
-    override fun sort(): KBv8Sort = ctx.mkBv8Sort()
+    override val sort: KBv8Sort
+        get() = ctx.mkBv8Sort()
 }
 
 class KBitVec16Value internal constructor(
@@ -60,7 +62,8 @@ class KBitVec16Value internal constructor(
 
     override fun decl(): KDecl<KBv16Sort> = ctx.mkBvDecl(numberValue)
 
-    override fun sort(): KBv16Sort = ctx.mkBv16Sort()
+    override val sort: KBv16Sort
+        get() = ctx.mkBv16Sort()
 }
 
 class KBitVec32Value internal constructor(
@@ -71,7 +74,8 @@ class KBitVec32Value internal constructor(
 
     override fun decl(): KDecl<KBv32Sort> = ctx.mkBvDecl(numberValue)
 
-    override fun sort(): KBv32Sort = ctx.mkBv32Sort()
+    override val sort: KBv32Sort
+        get() = ctx.mkBv32Sort()
 }
 
 class KBitVec64Value internal constructor(
@@ -82,7 +86,8 @@ class KBitVec64Value internal constructor(
 
     override fun decl(): KDecl<KBv64Sort> = ctx.mkBvDecl(numberValue)
 
-    override fun sort(): KBv64Sort = ctx.mkBv64Sort()
+    override val sort: KBv64Sort
+        get() = ctx.mkBv64Sort()
 }
 
 class KBitVecCustomValue internal constructor(
@@ -93,7 +98,7 @@ class KBitVecCustomValue internal constructor(
     init {
         require(binaryStringValue.length.toUInt() == sizeBits) {
             "Provided string $binaryStringValue consist of ${binaryStringValue.length} " +
-                    "symbols, but $sizeBits were expected"
+                "symbols, but $sizeBits were expected"
         }
     }
 
@@ -103,7 +108,8 @@ class KBitVecCustomValue internal constructor(
 
     override fun decl(): KDecl<KBvSort> = ctx.mkBvDecl(binaryStringValue, sizeBits)
 
-    override fun sort(): KBvSort = ctx.mkBvSort(sizeBits)
+    override val sort: KBvSort
+        get() = ctx.mkBvSort(sizeBits)
 }
 
 // expressions for operations
@@ -117,11 +123,18 @@ class KBvNotExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<S> = ctx.mkBvNotDecl(value.sort())
-
-    override fun sort(): S = value.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvNotDecl(value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = value.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += value
+    }
 }
 
 /**
@@ -134,9 +147,10 @@ class KBvReductionAndExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBv1Sort> = ctx.mkBvReductionAndDecl(value.sort())
+    override fun decl(): KDecl<KBv1Sort> = ctx.mkBvReductionAndDecl(value.sort)
 
-    override fun sort(): KBv1Sort = ctx.mkBv1Sort()
+    override val sort: KBv1Sort
+        get() = ctx.bv1Sort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBv1Sort> = transformer.transform(this)
 }
@@ -151,9 +165,10 @@ class KBvReductionOrExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBv1Sort> = ctx.mkBvReductionOrDecl(value.sort())
+    override fun decl(): KDecl<KBv1Sort> = ctx.mkBvReductionOrDecl(value.sort)
 
-    override fun sort(): KBv1Sort = ctx.mkBv1Sort()
+    override val sort: KBv1Sort
+        get() = ctx.bv1Sort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBv1Sort> = transformer.transform(this)
 }
@@ -169,11 +184,18 @@ class KBvAndExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvAndDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvAndDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -187,11 +209,18 @@ class KBvOrExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvOrDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvOrDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -205,11 +234,18 @@ class KBvXorExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvXorDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvXorDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -223,11 +259,18 @@ class KBvNAndExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvNAndDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvNAndDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -241,11 +284,18 @@ class KBvNorExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvNorDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvNorDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -259,12 +309,18 @@ class KBvXNorExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-
-    override fun decl(): KDecl<S> = ctx.mkBvXNorDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvXNorDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -277,11 +333,18 @@ class KBvNegationExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<S> = ctx.mkBvNegationDecl(value.sort())
-
-    override fun sort(): S = value.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvNegationDecl(value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = value.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += value
+    }
 }
 
 /**
@@ -295,11 +358,18 @@ class KBvAddExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvAddDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvAddDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -313,11 +383,18 @@ class KBvSubExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvSubDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvSubDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -331,11 +408,18 @@ class KBvMulExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvMulDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvMulDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -352,11 +436,18 @@ class KBvUnsignedDivExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvUnsignedDivDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvUnsignedDivDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -375,11 +466,18 @@ class KBvSignedDivExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvSignedDivDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvSignedDivDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -396,11 +494,18 @@ class KBvUnsignedRemExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvUnsignedRemDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvUnsignedRemDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -418,11 +523,18 @@ class KBvSignedRemExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvSignedRemDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvSignedRemDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -437,10 +549,18 @@ class KBvSignedModExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvSignedModDecl(arg0.sort(), arg1.sort())
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvSignedModDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -454,9 +574,10 @@ class KBvUnsignedLessExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvUnsignedLessDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkBvUnsignedLessDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -472,9 +593,10 @@ class KBvSignedLessExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSignedLessDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSignedLessDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -490,9 +612,10 @@ class KBvUnsignedLessOrEqualExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvUnsignedLessOrEqualDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkBvUnsignedLessOrEqualDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
@@ -509,9 +632,10 @@ class KBvSignedLessOrEqualExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSignedLessOrEqualDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSignedLessOrEqualDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
@@ -528,9 +652,10 @@ class KBvUnsignedGreaterOrEqualExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvUnsignedGreaterOrEqualDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkBvUnsignedGreaterOrEqualDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -546,9 +671,10 @@ class KBvSignedGreaterOrEqualExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSignedGreaterOrEqualDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSignedGreaterOrEqualDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -564,9 +690,10 @@ class KBvUnsignedGreaterExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvUnsignedGreaterDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkBvUnsignedGreaterDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -582,9 +709,10 @@ class KBvSignedGreaterExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSignedGreaterDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSignedGreaterDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -602,11 +730,19 @@ class KBvConcatExpr internal constructor(
     override val args: List<KExpr<KBvSort>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBvSort> = ctx.mkBvConcatDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): KBvSort = decl().sort
+    override fun decl(): KDecl<KBvSort> = ctx.mkBvConcatDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<KBvSort> = transformer.transform(this)
+
+    override val sort: KBvSort
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): KBvSort = ctx.mkBvSort(arg0.sort.sizeBits + arg1.sort.sizeBits)
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+        dependency += arg1
+    }
 }
 
 /**
@@ -626,7 +762,8 @@ class KBvExtractExpr internal constructor(
 
     override fun decl(): KDecl<KBvSort> = ctx.mkBvExtractDecl(high, low, value)
 
-    override fun sort(): KBvSort = ctx.mkBvSort((high - low + 1).toUInt())
+    override val sort: KBvSort
+        get() = ctx.mkBvSort((high - low + 1).toUInt())
 
     override fun accept(transformer: KTransformerBase): KExpr<KBvSort> = transformer.transform(this)
 }
@@ -645,12 +782,18 @@ class KBvSignExtensionExpr internal constructor(
     override val args: List<KExpr<KBvSort>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBvSort> = ctx.mkBvSignExtensionDecl(extensionSize, value.sort())
-
-    override fun sort(): KBvSort = ctx.mkBvSort(value.sort().sizeBits + extensionSize.toUInt())
+    override fun decl(): KDecl<KBvSort> = ctx.mkBvSignExtensionDecl(extensionSize, value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<KBvSort> = transformer.transform(this)
 
+    override val sort: KBvSort
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): KBvSort = ctx.mkBvSort(value.sort.sizeBits + extensionSize.toUInt())
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += value
+    }
 }
 
 /**
@@ -667,12 +810,18 @@ class KBvZeroExtensionExpr internal constructor(
     override val args: List<KExpr<KBvSort>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBvSort> = ctx.mkBvZeroExtensionDecl(extensionSize, value.sort())
-
-    override fun sort(): KBvSort = ctx.mkBvSort(value.sort().sizeBits + extensionSize.toUInt())
+    override fun decl(): KDecl<KBvSort> = ctx.mkBvZeroExtensionDecl(extensionSize, value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<KBvSort> = transformer.transform(this)
 
+    override val sort: KBvSort
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): KBvSort = ctx.mkBvSort(value.sort.sizeBits + extensionSize.toUInt())
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += value
+    }
 }
 
 /**
@@ -686,11 +835,18 @@ class KBvRepeatExpr internal constructor(
     override val args: List<KExpr<KBvSort>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBvSort> = ctx.mkBvRepeatDecl(repeatNumber, value.sort())
-
-    override fun sort(): KBvSort = ctx.mkBvSort(value.sort().sizeBits * repeatNumber.toUInt())
+    override fun decl(): KDecl<KBvSort> = ctx.mkBvRepeatDecl(repeatNumber, value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<KBvSort> = transformer.transform(this)
+
+    override val sort: KBvSort
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): KBvSort = ctx.mkBvSort(value.sort.sizeBits * repeatNumber.toUInt())
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += value
+    }
 
 }
 
@@ -707,12 +863,18 @@ class KBvShiftLeftExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvShiftLeftDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvShiftLeftDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -728,12 +890,18 @@ class KBvLogicalShiftRightExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvLogicalShiftRightDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvLogicalShiftRightDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -750,11 +918,18 @@ class KBvArithShiftRightExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvArithShiftRightDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvArithShiftRightDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 
 }
 
@@ -771,11 +946,18 @@ class KBvRotateLeftExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvRotateLeftDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvRotateLeftDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -791,11 +973,18 @@ class KBvRotateLeftIndexedExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<S> = ctx.mkBvRotateLeftIndexedDecl(rotationNumber, value.sort())
-
-    override fun sort(): S = value.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvRotateLeftIndexedDecl(rotationNumber, value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = value.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += value
+    }
 }
 
 /**
@@ -811,11 +1000,18 @@ class KBvRotateRightExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvRotateRightDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvRotateRightDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 /**
@@ -831,11 +1027,18 @@ class KBvRotateRightIndexedExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<S> = ctx.mkBvRotateRightIndexedDecl(rotationNumber, value.sort())
-
-    override fun sort(): S = value.sort()
+    override fun decl(): KDecl<S> = ctx.mkBvRotateRightIndexedDecl(rotationNumber, value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = value.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += value
+    }
 }
 
 /**
@@ -855,9 +1058,10 @@ class KBv2IntExpr internal constructor(
     override val args: List<KExpr<KBvSort>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KIntSort> = ctx.mkBv2IntDecl(value.sort(), isSigned)
+    override fun decl(): KDecl<KIntSort> = ctx.mkBv2IntDecl(value.sort, isSigned)
 
-    override fun sort(): KIntSort = ctx.mkIntSort()
+    override val sort: KIntSort
+        get() = ctx.intSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KIntSort> = transformer.transform(this)
 }
@@ -871,9 +1075,10 @@ class KBvAddNoOverflowExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvAddNoOverflowDecl(arg0.sort(), arg1.sort(), isSigned)
+    override fun decl(): KDecl<KBoolSort> = ctx.mkBvAddNoOverflowDecl(arg0.sort, arg1.sort, isSigned)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -886,9 +1091,10 @@ class KBvAddNoUnderflowExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvAddNoUnderflowDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkBvAddNoUnderflowDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -901,9 +1107,10 @@ class KBvSubNoOverflowExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSubNoOverflowDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSubNoOverflowDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -917,9 +1124,10 @@ class KBvSubNoUnderflowExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSubNoUnderflowDecl(arg0.sort(), arg1.sort(), isSigned)
+    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSubNoUnderflowDecl(arg0.sort, arg1.sort, isSigned)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -932,9 +1140,10 @@ class KBvDivNoOverflowExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvDivNoOverflowDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkBvDivNoOverflowDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -946,9 +1155,10 @@ class KBvNegNoOverflowExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvNegationNoOverflowDecl(value.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkBvNegationNoOverflowDecl(value.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -962,9 +1172,10 @@ class KBvMulNoOverflowExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvMulNoOverflowDecl(arg0.sort(), arg1.sort(), isSigned)
+    override fun decl(): KDecl<KBoolSort> = ctx.mkBvMulNoOverflowDecl(arg0.sort, arg1.sort, isSigned)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -977,9 +1188,10 @@ class KBvMulNoUnderflowExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvMulNoUnderflowDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkBvMulNoUnderflowDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KBitVecExprs.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KBitVecExprs.kt
@@ -3,9 +3,9 @@ package org.ksmt.expr
 import org.ksmt.KContext
 import org.ksmt.decl.KDecl
 import org.ksmt.expr.transformer.KTransformerBase
-import org.ksmt.sort.KBv1Sort
 import org.ksmt.sort.KBoolSort
 import org.ksmt.sort.KBv16Sort
+import org.ksmt.sort.KBv1Sort
 import org.ksmt.sort.KBv32Sort
 import org.ksmt.sort.KBv64Sort
 import org.ksmt.sort.KBv8Sort
@@ -29,7 +29,8 @@ class KBitVec1Value internal constructor(
 
     override val stringValue: String = if (value) "1" else "0"
 
-    override fun decl(): KDecl<KBv1Sort> = ctx.mkBvDecl(value)
+    override val decl: KDecl<KBv1Sort>
+        get() = ctx.mkBvDecl(value)
 
     override val sort: KBv1Sort
         get() = ctx.bv1Sort
@@ -48,7 +49,8 @@ class KBitVec8Value internal constructor(
 ) : KBitVecNumberValue<KBv8Sort, Byte>(ctx, byteValue) {
     override fun accept(transformer: KTransformerBase): KExpr<KBv8Sort> = transformer.transform(this)
 
-    override fun decl(): KDecl<KBv8Sort> = ctx.mkBvDecl(numberValue)
+    override val decl: KDecl<KBv8Sort>
+        get() = ctx.mkBvDecl(numberValue)
 
     override val sort: KBv8Sort
         get() = ctx.mkBv8Sort()
@@ -60,7 +62,8 @@ class KBitVec16Value internal constructor(
 ) : KBitVecNumberValue<KBv16Sort, Short>(ctx, shortValue) {
     override fun accept(transformer: KTransformerBase): KExpr<KBv16Sort> = transformer.transform(this)
 
-    override fun decl(): KDecl<KBv16Sort> = ctx.mkBvDecl(numberValue)
+    override val decl: KDecl<KBv16Sort>
+        get() = ctx.mkBvDecl(numberValue)
 
     override val sort: KBv16Sort
         get() = ctx.mkBv16Sort()
@@ -72,7 +75,8 @@ class KBitVec32Value internal constructor(
 ) : KBitVecNumberValue<KBv32Sort, Int>(ctx, intValue) {
     override fun accept(transformer: KTransformerBase): KExpr<KBv32Sort> = transformer.transform(this)
 
-    override fun decl(): KDecl<KBv32Sort> = ctx.mkBvDecl(numberValue)
+    override val decl: KDecl<KBv32Sort>
+        get() = ctx.mkBvDecl(numberValue)
 
     override val sort: KBv32Sort
         get() = ctx.mkBv32Sort()
@@ -84,7 +88,8 @@ class KBitVec64Value internal constructor(
 ) : KBitVecNumberValue<KBv64Sort, Long>(ctx, longValue) {
     override fun accept(transformer: KTransformerBase): KExpr<KBv64Sort> = transformer.transform(this)
 
-    override fun decl(): KDecl<KBv64Sort> = ctx.mkBvDecl(numberValue)
+    override val decl: KDecl<KBv64Sort>
+        get() = ctx.mkBvDecl(numberValue)
 
     override val sort: KBv64Sort
         get() = ctx.mkBv64Sort()
@@ -98,7 +103,7 @@ class KBitVecCustomValue internal constructor(
     init {
         require(binaryStringValue.length.toUInt() == sizeBits) {
             "Provided string $binaryStringValue consist of ${binaryStringValue.length} " +
-                "symbols, but $sizeBits were expected"
+                    "symbols, but $sizeBits were expected"
         }
     }
 
@@ -106,7 +111,8 @@ class KBitVecCustomValue internal constructor(
 
     override val stringValue: String = binaryStringValue
 
-    override fun decl(): KDecl<KBvSort> = ctx.mkBvDecl(binaryStringValue, sizeBits)
+    override val decl: KDecl<KBvSort>
+        get() = ctx.mkBvDecl(binaryStringValue, sizeBits)
 
     override val sort: KBvSort
         get() = ctx.mkBvSort(sizeBits)
@@ -123,7 +129,8 @@ class KBvNotExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<S> = ctx.mkBvNotDecl(value.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvNotDecl(value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -147,7 +154,8 @@ class KBvReductionAndExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBv1Sort> = ctx.mkBvReductionAndDecl(value.sort)
+    override val decl: KDecl<KBv1Sort>
+        get() = ctx.mkBvReductionAndDecl(value.sort)
 
     override val sort: KBv1Sort
         get() = ctx.bv1Sort
@@ -165,7 +173,8 @@ class KBvReductionOrExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBv1Sort> = ctx.mkBvReductionOrDecl(value.sort)
+    override val decl: KDecl<KBv1Sort>
+        get() = ctx.mkBvReductionOrDecl(value.sort)
 
     override val sort: KBv1Sort
         get() = ctx.bv1Sort
@@ -184,7 +193,8 @@ class KBvAndExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvAndDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvAndDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -209,7 +219,8 @@ class KBvOrExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvOrDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvOrDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -234,7 +245,8 @@ class KBvXorExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvXorDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvXorDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -259,7 +271,8 @@ class KBvNAndExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvNAndDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvNAndDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -284,7 +297,8 @@ class KBvNorExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvNorDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvNorDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -309,7 +323,8 @@ class KBvXNorExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvXNorDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvXNorDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -333,7 +348,8 @@ class KBvNegationExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<S> = ctx.mkBvNegationDecl(value.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvNegationDecl(value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -358,7 +374,8 @@ class KBvAddExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvAddDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvAddDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -383,7 +400,8 @@ class KBvSubExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvSubDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvSubDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -408,7 +426,8 @@ class KBvMulExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvMulDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvMulDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -436,7 +455,8 @@ class KBvUnsignedDivExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvUnsignedDivDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvUnsignedDivDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -466,7 +486,8 @@ class KBvSignedDivExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvSignedDivDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvSignedDivDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -494,7 +515,8 @@ class KBvUnsignedRemExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvUnsignedRemDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvUnsignedRemDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -523,7 +545,8 @@ class KBvSignedRemExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvSignedRemDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvSignedRemDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -549,7 +572,8 @@ class KBvSignedModExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvSignedModDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvSignedModDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -574,7 +598,8 @@ class KBvUnsignedLessExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvUnsignedLessDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkBvUnsignedLessDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -593,7 +618,8 @@ class KBvSignedLessExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSignedLessDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkBvSignedLessDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -612,7 +638,8 @@ class KBvUnsignedLessOrEqualExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvUnsignedLessOrEqualDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkBvUnsignedLessOrEqualDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -632,7 +659,8 @@ class KBvSignedLessOrEqualExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSignedLessOrEqualDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkBvSignedLessOrEqualDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -652,7 +680,8 @@ class KBvUnsignedGreaterOrEqualExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvUnsignedGreaterOrEqualDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkBvUnsignedGreaterOrEqualDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -671,7 +700,8 @@ class KBvSignedGreaterOrEqualExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSignedGreaterOrEqualDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkBvSignedGreaterOrEqualDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -690,7 +720,8 @@ class KBvUnsignedGreaterExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvUnsignedGreaterDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkBvUnsignedGreaterDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -709,7 +740,8 @@ class KBvSignedGreaterExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSignedGreaterDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkBvSignedGreaterDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -730,7 +762,8 @@ class KBvConcatExpr internal constructor(
     override val args: List<KExpr<KBvSort>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBvSort> = ctx.mkBvConcatDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBvSort>
+        get() = ctx.mkBvConcatDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<KBvSort> = transformer.transform(this)
 
@@ -760,7 +793,8 @@ class KBvExtractExpr internal constructor(
     override val args: List<KExpr<KBvSort>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBvSort> = ctx.mkBvExtractDecl(high, low, value)
+    override val decl: KDecl<KBvSort>
+        get() = ctx.mkBvExtractDecl(high, low, value)
 
     override val sort: KBvSort
         get() = ctx.mkBvSort((high - low + 1).toUInt())
@@ -782,7 +816,8 @@ class KBvSignExtensionExpr internal constructor(
     override val args: List<KExpr<KBvSort>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBvSort> = ctx.mkBvSignExtensionDecl(extensionSize, value.sort)
+    override val decl: KDecl<KBvSort>
+        get() = ctx.mkBvSignExtensionDecl(extensionSize, value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<KBvSort> = transformer.transform(this)
 
@@ -810,7 +845,8 @@ class KBvZeroExtensionExpr internal constructor(
     override val args: List<KExpr<KBvSort>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBvSort> = ctx.mkBvZeroExtensionDecl(extensionSize, value.sort)
+    override val decl: KDecl<KBvSort>
+        get() = ctx.mkBvZeroExtensionDecl(extensionSize, value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<KBvSort> = transformer.transform(this)
 
@@ -835,7 +871,8 @@ class KBvRepeatExpr internal constructor(
     override val args: List<KExpr<KBvSort>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBvSort> = ctx.mkBvRepeatDecl(repeatNumber, value.sort)
+    override val decl: KDecl<KBvSort>
+        get() = ctx.mkBvRepeatDecl(repeatNumber, value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<KBvSort> = transformer.transform(this)
 
@@ -863,7 +900,8 @@ class KBvShiftLeftExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvShiftLeftDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvShiftLeftDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -890,7 +928,8 @@ class KBvLogicalShiftRightExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvLogicalShiftRightDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvLogicalShiftRightDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -918,7 +957,8 @@ class KBvArithShiftRightExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvArithShiftRightDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvArithShiftRightDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -946,7 +986,8 @@ class KBvRotateLeftExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvRotateLeftDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvRotateLeftDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -973,7 +1014,8 @@ class KBvRotateLeftIndexedExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<S> = ctx.mkBvRotateLeftIndexedDecl(rotationNumber, value.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvRotateLeftIndexedDecl(rotationNumber, value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -1000,7 +1042,8 @@ class KBvRotateRightExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkBvRotateRightDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvRotateRightDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -1027,7 +1070,8 @@ class KBvRotateRightIndexedExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<S> = ctx.mkBvRotateRightIndexedDecl(rotationNumber, value.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkBvRotateRightIndexedDecl(rotationNumber, value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -1058,7 +1102,8 @@ class KBv2IntExpr internal constructor(
     override val args: List<KExpr<KBvSort>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KIntSort> = ctx.mkBv2IntDecl(value.sort, isSigned)
+    override val decl: KDecl<KIntSort>
+        get() = ctx.mkBv2IntDecl(value.sort, isSigned)
 
     override val sort: KIntSort
         get() = ctx.intSort
@@ -1075,7 +1120,8 @@ class KBvAddNoOverflowExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvAddNoOverflowDecl(arg0.sort, arg1.sort, isSigned)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkBvAddNoOverflowDecl(arg0.sort, arg1.sort, isSigned)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -1091,7 +1137,8 @@ class KBvAddNoUnderflowExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvAddNoUnderflowDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkBvAddNoUnderflowDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -1107,7 +1154,8 @@ class KBvSubNoOverflowExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSubNoOverflowDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkBvSubNoOverflowDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -1124,7 +1172,8 @@ class KBvSubNoUnderflowExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvSubNoUnderflowDecl(arg0.sort, arg1.sort, isSigned)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkBvSubNoUnderflowDecl(arg0.sort, arg1.sort, isSigned)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -1140,7 +1189,8 @@ class KBvDivNoOverflowExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvDivNoOverflowDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkBvDivNoOverflowDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -1155,7 +1205,8 @@ class KBvNegNoOverflowExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvNegationNoOverflowDecl(value.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkBvNegationNoOverflowDecl(value.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -1172,7 +1223,8 @@ class KBvMulNoOverflowExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvMulNoOverflowDecl(arg0.sort, arg1.sort, isSigned)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkBvMulNoOverflowDecl(arg0.sort, arg1.sort, isSigned)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -1188,7 +1240,8 @@ class KBvMulNoUnderflowExpr<S : KBvSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkBvMulNoUnderflowDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkBvMulNoUnderflowDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KExpr.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KExpr.kt
@@ -6,7 +6,10 @@ import org.ksmt.expr.transformer.KTransformerBase
 import org.ksmt.sort.KSort
 
 abstract class KExpr<T : KSort>(ctx: KContext) : KAst(ctx) {
-    abstract fun sort(): T
+    abstract val sort: T
+
+    @Deprecated("Use property access syntax", ReplaceWith("sort"))
+    fun sort(): T = sort
 
     abstract fun accept(transformer: KTransformerBase): KExpr<T>
 
@@ -14,4 +17,7 @@ abstract class KExpr<T : KSort>(ctx: KContext) : KAst(ctx) {
     override fun equals(other: Any?): Boolean = this === other
 
     override fun hashCode(): Int = System.identityHashCode(this)
+
+    open fun computeExprSort(): T = sort
+    open fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {}
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KExpr.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KExpr.kt
@@ -6,9 +6,10 @@ import org.ksmt.expr.transformer.KTransformerBase
 import org.ksmt.sort.KSort
 
 abstract class KExpr<T : KSort>(ctx: KContext) : KAst(ctx) {
+
     abstract val sort: T
 
-    @Deprecated("Use property access syntax", ReplaceWith("sort"))
+    @Deprecated("Use property", ReplaceWith("sort"))
     fun sort(): T = sort
 
     abstract fun accept(transformer: KTransformerBase): KExpr<T>
@@ -18,6 +19,16 @@ abstract class KExpr<T : KSort>(ctx: KContext) : KAst(ctx) {
 
     override fun hashCode(): Int = System.identityHashCode(this)
 
+    /**
+     * Some expressions require evaluation of nested expressions sorts in order to compute the sort.
+     * To compute sort non-recursively, override this method and use [KContext.getExprSort].
+     * */
     open fun computeExprSort(): T = sort
+
+    /**
+     * Add the expressions, needed to compute the sort, to the provided [dependency] list.
+     * To compute sort non-recursively, override this method.
+     * @see [computeExprSort]
+     * */
     open fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {}
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KFloatingPointExpr.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KFloatingPointExpr.kt
@@ -56,7 +56,8 @@ class KFp16Value internal constructor(
 
     override fun decl(): KDecl<KFp16Sort> = ctx.mkFp16Decl(value)
 
-    override fun sort(): KFp16Sort = ctx.mkFp16Sort()
+    override val sort: KFp16Sort
+        get() = ctx.mkFp16Sort()
 
     override fun accept(transformer: KTransformerBase): KExpr<KFp16Sort> = transformer.transform(this)
 }
@@ -72,7 +73,8 @@ class KFp32Value internal constructor(
 ) {
     override fun decl(): KDecl<KFp32Sort> = ctx.mkFp32Decl(value)
 
-    override fun sort(): KFp32Sort = ctx.mkFp32Sort()
+    override val sort: KFp32Sort
+        get() = ctx.mkFp32Sort()
 
     override fun accept(transformer: KTransformerBase): KExpr<KFp32Sort> = transformer.transform(this)
 }
@@ -88,7 +90,8 @@ class KFp64Value internal constructor(
 ) {
     override fun decl(): KDecl<KFp64Sort> = ctx.mkFp64Decl(value)
 
-    override fun sort(): KFp64Sort = ctx.mkFp64Sort()
+    override val sort: KFp64Sort
+        get() = ctx.mkFp64Sort()
 
     override fun accept(transformer: KTransformerBase): KExpr<KFp64Sort> = transformer.transform(this)
 }
@@ -112,7 +115,8 @@ class KFp128Value internal constructor(
 ) {
     override fun decl(): KDecl<KFp128Sort> = ctx.mkFp128Decl(significandValue, exponentValue, signBit)
 
-    override fun sort(): KFp128Sort = ctx.mkFp128Sort()
+    override val sort: KFp128Sort
+        get() = ctx.mkFp128Sort()
 
     override fun accept(transformer: KTransformerBase): KExpr<KFp128Sort> = transformer.transform(this)
 }
@@ -151,7 +155,8 @@ class KFpCustomSizeValue internal constructor(
         signBit
     )
 
-    override fun sort(): KFpSort = ctx.mkFpSort(exponentSize, significandSize)
+    override val sort: KFpSort
+        get() = ctx.mkFpSort(exponentSize, significandSize)
 
     override fun accept(transformer: KTransformerBase): KExpr<KFpSort> = transformer.transform(this)
 }
@@ -163,9 +168,16 @@ class KFpAbsExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<S> = ctx.mkFpAbsDecl(value.sort())
+    override fun decl(): KDecl<S> = ctx.mkFpAbsDecl(value.sort)
 
-    override fun sort(): S = value.sort()
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = value.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += value
+    }
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 }
@@ -180,9 +192,16 @@ class KFpNegationExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<S> = ctx.mkFpNegationDecl(value.sort())
+    override fun decl(): KDecl<S> = ctx.mkFpNegationDecl(value.sort)
 
-    override fun sort(): S = value.sort()
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = value.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += value
+    }
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 }
@@ -199,7 +218,14 @@ class KFpAddExpr<S : KFpSort> internal constructor(
 
     override fun decl(): KDecl<S> = with(ctx) { mkFpAddDecl(roundingMode.sort, arg0.sort, arg1.sort) }
 
-    override fun sort(): S = arg0.sort()
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 }
@@ -215,7 +241,14 @@ class KFpSubExpr<S : KFpSort> internal constructor(
 
     override fun decl(): KDecl<S> = with(ctx) { mkFpSubDecl(roundingMode.sort, arg0.sort, arg1.sort) }
 
-    override fun sort(): S = arg0.sort()
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 }
@@ -231,7 +264,14 @@ class KFpMulExpr<S : KFpSort> internal constructor(
 
     override fun decl(): KDecl<S> = with(ctx) { mkFpMulDecl(roundingMode.sort, arg0.sort, arg1.sort) }
 
-    override fun sort(): S = arg0.sort()
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 }
@@ -247,7 +287,14 @@ class KFpDivExpr<S : KFpSort> internal constructor(
 
     override fun decl(): KDecl<S> = with(ctx) { mkFpDivDecl(roundingMode.sort, arg0.sort, arg1.sort) }
 
-    override fun sort(): S = arg0.sort()
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 }
@@ -271,7 +318,14 @@ class KFpFusedMulAddExpr<S : KFpSort> internal constructor(
         )
     }
 
-    override fun sort(): S = arg0.sort()
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -287,7 +341,14 @@ class KFpSqrtExpr<S : KFpSort> internal constructor(
 
     override fun decl(): KDecl<S> = with(ctx) { mkFpSqrtDecl(roundingMode.sort, value.sort) }
 
-    override fun sort(): S = value.sort()
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = value.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += value
+    }
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -301,9 +362,16 @@ class KFpRemExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkFpRemDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<S> = ctx.mkFpRemDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): S = arg0.sort()
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 }
@@ -318,7 +386,14 @@ class KFpRoundToIntegralExpr<S : KFpSort> internal constructor(
 
     override fun decl(): KDecl<S> = with(ctx) { mkFpRoundToIntegralDecl(roundingMode.sort, value.sort) }
 
-    override fun sort(): S = value.sort()
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = value.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += value
+    }
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -332,9 +407,16 @@ class KFpMinExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkFpMinDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<S> = ctx.mkFpMinDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): S = arg0.sort()
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 }
@@ -347,11 +429,18 @@ class KFpMaxExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkFpMaxDecl(arg0.sort(), arg1.sort())
-
-    override fun sort(): S = arg0.sort()
+    override fun decl(): KDecl<S> = ctx.mkFpMaxDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
+
+    override val sort: S
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): S = arg0.sort
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += arg0
+    }
 }
 
 class KFpLessOrEqualExpr<S : KFpSort> internal constructor(
@@ -362,9 +451,10 @@ class KFpLessOrEqualExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpLessOrEqualDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkFpLessOrEqualDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -377,9 +467,10 @@ class KFpLessExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpLessDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkFpLessDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -392,9 +483,10 @@ class KFpGreaterOrEqualExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpGreaterOrEqualDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkFpGreaterOrEqualDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -407,9 +499,10 @@ class KFpGreaterExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpGreaterDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkFpGreaterDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -422,9 +515,10 @@ class KFpEqualExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpEqualDecl(arg0.sort(), arg1.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkFpEqualDecl(arg0.sort, arg1.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -436,9 +530,10 @@ class KFpIsNormalExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsNormalDecl(value.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsNormalDecl(value.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -450,9 +545,10 @@ class KFpIsSubnormalExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsSubnormalDecl(value.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsSubnormalDecl(value.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -464,9 +560,10 @@ class KFpIsZeroExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsZeroDecl(value.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsZeroDecl(value.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -478,9 +575,10 @@ class KFpIsInfiniteExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsInfiniteDecl(value.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsInfiniteDecl(value.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -492,9 +590,10 @@ class KFpIsNaNExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsNaNDecl(value.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsNaNDecl(value.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -506,9 +605,10 @@ class KFpIsNegativeExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsNegativeDecl(value.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsNegativeDecl(value.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -520,9 +620,10 @@ class KFpIsPositiveExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsPositiveDecl(value.sort())
+    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsPositiveDecl(value.sort)
 
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> = transformer.transform(this)
 }
@@ -543,7 +644,8 @@ class KFpToBvExpr<S : KFpSort> internal constructor(
         mkFpToBvDecl(roundingMode.sort, value.sort, bvSize, isSigned)
     }
 
-    override fun sort(): KBvSort = decl().sort
+    override val sort: KBvSort
+        get() = ctx.mkBvSort(bvSize.toUInt())
 
     override fun accept(transformer: KTransformerBase): KExpr<KBvSort> = transformer.transform(this)
 
@@ -556,9 +658,10 @@ class KFpToRealExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KRealSort> = ctx.mkFpToRealDecl(value.sort())
+    override fun decl(): KDecl<KRealSort> = ctx.mkFpToRealDecl(value.sort)
 
-    override fun sort(): KRealSort = ctx.mkRealSort()
+    override val sort: KRealSort
+        get() = ctx.realSort
 
     override fun accept(transformer: KTransformerBase): KExpr<KRealSort> = transformer.transform(this)
 }
@@ -570,16 +673,24 @@ class KFpToIEEEBvExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBvSort> = ctx.mkFpToIEEEBvDecl(value.sort())
-
-    override fun sort(): KBvSort = decl().sort
+    override fun decl(): KDecl<KBvSort> = ctx.mkFpToIEEEBvDecl(value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<KBvSort> = transformer.transform(this)
+
+    override val sort: KBvSort
+        get() = ctx.getExprSort(this)
+
+    override fun computeExprSort(): KBvSort =
+        value.sort.let { ctx.mkBvSort(it.significandBits + it.exponentBits) }
+
+    override fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {
+        dependency += value
+    }
 }
 
 class KFpFromBvExpr<S : KFpSort> internal constructor(
     ctx: KContext,
-    val sort: S,
+    override val sort: S,
     val sign: KExpr<KBv1Sort>,
     val exponent: KExpr<out KBvSort>,
     val significand: KExpr<out KBvSort>,
@@ -591,14 +702,12 @@ class KFpFromBvExpr<S : KFpSort> internal constructor(
         mkFpFromBvDecl(sign.sort, exponent.sort, significand.sort)
     }
 
-    override fun sort(): S = sort
-
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 }
 
 class KFpToFpExpr<S : KFpSort> internal constructor(
     ctx: KContext,
-    val sort: S,
+    override val sort: S,
     val roundingMode: KExpr<KFpRoundingModeSort>,
     val value: KExpr<out KFpSort>
 ) : KApp<S, KExpr<*>>(ctx) {
@@ -609,14 +718,12 @@ class KFpToFpExpr<S : KFpSort> internal constructor(
         mkFpToFpDecl(sort, roundingMode.sort, value.sort)
     }
 
-    override fun sort(): S = sort
-
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 }
 
 class KRealToFpExpr<S : KFpSort> internal constructor(
     ctx: KContext,
-    val sort: S,
+    override val sort: S,
     val roundingMode: KExpr<KFpRoundingModeSort>,
     val value: KExpr<KRealSort>
 ) : KApp<S, KExpr<*>>(ctx) {
@@ -627,14 +734,12 @@ class KRealToFpExpr<S : KFpSort> internal constructor(
         mkRealToFpDecl(sort, roundingMode.sort, value.sort)
     }
 
-    override fun sort(): S = sort
-
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 }
 
 class KBvToFpExpr<S : KFpSort> internal constructor(
     ctx: KContext,
-    val sort: S,
+    override val sort: S,
     val roundingMode: KExpr<KFpRoundingModeSort>,
     val value: KExpr<KBvSort>,
     val signed: Boolean
@@ -645,8 +750,6 @@ class KBvToFpExpr<S : KFpSort> internal constructor(
     override fun decl(): KDecl<S> = with(ctx) {
         mkBvToFpDecl(sort, roundingMode.sort, value.sort, signed)
     }
-
-    override fun sort(): S = sort
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KFloatingPointExpr.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KFloatingPointExpr.kt
@@ -54,7 +54,8 @@ class KFp16Value internal constructor(
         // TODO add checks for the bounds
     }
 
-    override fun decl(): KDecl<KFp16Sort> = ctx.mkFp16Decl(value)
+    override val decl: KDecl<KFp16Sort>
+        get() = ctx.mkFp16Decl(value)
 
     override val sort: KFp16Sort
         get() = ctx.mkFp16Sort()
@@ -71,7 +72,8 @@ class KFp32Value internal constructor(
     exponent = with(ctx) { value.getExponent(isBiased = true).toBv(KFp32Sort.exponentBits) },
     signBit = value.booleanSignBit
 ) {
-    override fun decl(): KDecl<KFp32Sort> = ctx.mkFp32Decl(value)
+    override val decl: KDecl<KFp32Sort>
+        get() = ctx.mkFp32Decl(value)
 
     override val sort: KFp32Sort
         get() = ctx.mkFp32Sort()
@@ -88,7 +90,8 @@ class KFp64Value internal constructor(
     exponent = with(ctx) { value.getExponent(isBiased = true).toBv(KFp64Sort.exponentBits) },
     signBit = value.booleanSignBit
 ) {
-    override fun decl(): KDecl<KFp64Sort> = ctx.mkFp64Decl(value)
+    override val decl: KDecl<KFp64Sort>
+        get() = ctx.mkFp64Decl(value)
 
     override val sort: KFp64Sort
         get() = ctx.mkFp64Sort()
@@ -113,7 +116,8 @@ class KFp128Value internal constructor(
     exponent = with(ctx) { exponentValue.toBv(KFp128Sort.exponentBits) },
     signBit
 ) {
-    override fun decl(): KDecl<KFp128Sort> = ctx.mkFp128Decl(significandValue, exponentValue, signBit)
+    override val decl: KDecl<KFp128Sort>
+        get() = ctx.mkFp128Decl(significandValue, exponentValue, signBit)
 
     override val sort: KFp128Sort
         get() = ctx.mkFp128Sort()
@@ -147,13 +151,14 @@ class KFpCustomSizeValue internal constructor(
         }
     }
 
-    override fun decl(): KDecl<KFpSort> = ctx.mkFpCustomSizeDecl(
-        significandSize,
-        exponentSize,
-        significandValue,
-        exponentValue,
-        signBit
-    )
+    override val decl: KDecl<KFpSort>
+        get() = ctx.mkFpCustomSizeDecl(
+            significandSize,
+            exponentSize,
+            significandValue,
+            exponentValue,
+            signBit
+        )
 
     override val sort: KFpSort
         get() = ctx.mkFpSort(exponentSize, significandSize)
@@ -168,7 +173,8 @@ class KFpAbsExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<S> = ctx.mkFpAbsDecl(value.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkFpAbsDecl(value.sort)
 
     override val sort: S
         get() = ctx.getExprSort(this)
@@ -192,7 +198,8 @@ class KFpNegationExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<S> = ctx.mkFpNegationDecl(value.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkFpNegationDecl(value.sort)
 
     override val sort: S
         get() = ctx.getExprSort(this)
@@ -216,7 +223,8 @@ class KFpAddExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<*>>
         get() = listOf(roundingMode, arg0, arg1)
 
-    override fun decl(): KDecl<S> = with(ctx) { mkFpAddDecl(roundingMode.sort, arg0.sort, arg1.sort) }
+    override val decl: KDecl<S>
+        get() = ctx.mkFpAddDecl(roundingMode.sort, arg0.sort, arg1.sort)
 
     override val sort: S
         get() = ctx.getExprSort(this)
@@ -239,7 +247,8 @@ class KFpSubExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<*>>
         get() = listOf(roundingMode, arg0, arg1)
 
-    override fun decl(): KDecl<S> = with(ctx) { mkFpSubDecl(roundingMode.sort, arg0.sort, arg1.sort) }
+    override val decl: KDecl<S>
+        get() = ctx.mkFpSubDecl(roundingMode.sort, arg0.sort, arg1.sort)
 
     override val sort: S
         get() = ctx.getExprSort(this)
@@ -262,7 +271,8 @@ class KFpMulExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<*>>
         get() = listOf(roundingMode, arg0, arg1)
 
-    override fun decl(): KDecl<S> = with(ctx) { mkFpMulDecl(roundingMode.sort, arg0.sort, arg1.sort) }
+    override val decl: KDecl<S>
+        get() = ctx.mkFpMulDecl(roundingMode.sort, arg0.sort, arg1.sort)
 
     override val sort: S
         get() = ctx.getExprSort(this)
@@ -285,7 +295,8 @@ class KFpDivExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<*>>
         get() = listOf(roundingMode, arg0, arg1)
 
-    override fun decl(): KDecl<S> = with(ctx) { mkFpDivDecl(roundingMode.sort, arg0.sort, arg1.sort) }
+    override val decl: KDecl<S>
+        get() = ctx.mkFpDivDecl(roundingMode.sort, arg0.sort, arg1.sort)
 
     override val sort: S
         get() = ctx.getExprSort(this)
@@ -309,14 +320,14 @@ class KFpFusedMulAddExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<*>>
         get() = listOf(roundingMode, arg0, arg1, arg2)
 
-    override fun decl(): KDecl<S> = with(ctx) {
-        mkFpFusedMulAddDecl(
+    override val decl: KDecl<S>
+        get() = ctx.mkFpFusedMulAddDecl(
             roundingMode.sort,
             arg0.sort,
             arg1.sort,
             arg2.sort
         )
-    }
+
 
     override val sort: S
         get() = ctx.getExprSort(this)
@@ -339,7 +350,8 @@ class KFpSqrtExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<*>>
         get() = listOf(roundingMode, value)
 
-    override fun decl(): KDecl<S> = with(ctx) { mkFpSqrtDecl(roundingMode.sort, value.sort) }
+    override val decl: KDecl<S>
+        get() = ctx.mkFpSqrtDecl(roundingMode.sort, value.sort)
 
     override val sort: S
         get() = ctx.getExprSort(this)
@@ -362,7 +374,8 @@ class KFpRemExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkFpRemDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkFpRemDecl(arg0.sort, arg1.sort)
 
     override val sort: S
         get() = ctx.getExprSort(this)
@@ -384,7 +397,8 @@ class KFpRoundToIntegralExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<*>>
         get() = listOf(roundingMode, value)
 
-    override fun decl(): KDecl<S> = with(ctx) { mkFpRoundToIntegralDecl(roundingMode.sort, value.sort) }
+    override val decl: KDecl<S>
+        get() = ctx.mkFpRoundToIntegralDecl(roundingMode.sort, value.sort)
 
     override val sort: S
         get() = ctx.getExprSort(this)
@@ -407,7 +421,8 @@ class KFpMinExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkFpMinDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkFpMinDecl(arg0.sort, arg1.sort)
 
     override val sort: S
         get() = ctx.getExprSort(this)
@@ -429,7 +444,8 @@ class KFpMaxExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<S> = ctx.mkFpMaxDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<S>
+        get() = ctx.mkFpMaxDecl(arg0.sort, arg1.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 
@@ -451,7 +467,8 @@ class KFpLessOrEqualExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpLessOrEqualDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkFpLessOrEqualDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -467,7 +484,8 @@ class KFpLessExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpLessDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkFpLessDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -483,7 +501,8 @@ class KFpGreaterOrEqualExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpGreaterOrEqualDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkFpGreaterOrEqualDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -499,7 +518,8 @@ class KFpGreaterExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpGreaterDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkFpGreaterDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -515,7 +535,8 @@ class KFpEqualExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(arg0, arg1)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpEqualDecl(arg0.sort, arg1.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkFpEqualDecl(arg0.sort, arg1.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -530,7 +551,8 @@ class KFpIsNormalExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsNormalDecl(value.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkFpIsNormalDecl(value.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -545,7 +567,8 @@ class KFpIsSubnormalExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsSubnormalDecl(value.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkFpIsSubnormalDecl(value.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -560,7 +583,8 @@ class KFpIsZeroExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsZeroDecl(value.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkFpIsZeroDecl(value.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -575,7 +599,8 @@ class KFpIsInfiniteExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsInfiniteDecl(value.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkFpIsInfiniteDecl(value.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -590,7 +615,8 @@ class KFpIsNaNExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsNaNDecl(value.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkFpIsNaNDecl(value.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -605,7 +631,8 @@ class KFpIsNegativeExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsNegativeDecl(value.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkFpIsNegativeDecl(value.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -620,7 +647,8 @@ class KFpIsPositiveExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBoolSort> = ctx.mkFpIsPositiveDecl(value.sort)
+    override val decl: KDecl<KBoolSort>
+        get() = ctx.mkFpIsPositiveDecl(value.sort)
 
     override val sort: KBoolSort
         get() = ctx.boolSort
@@ -640,9 +668,8 @@ class KFpToBvExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<*>>
         get() = listOf(roundingMode, value)
 
-    override fun decl(): KDecl<KBvSort> = with(ctx) {
-        mkFpToBvDecl(roundingMode.sort, value.sort, bvSize, isSigned)
-    }
+    override val decl: KDecl<KBvSort>
+        get() = ctx.mkFpToBvDecl(roundingMode.sort, value.sort, bvSize, isSigned)
 
     override val sort: KBvSort
         get() = ctx.mkBvSort(bvSize.toUInt())
@@ -658,7 +685,8 @@ class KFpToRealExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KRealSort> = ctx.mkFpToRealDecl(value.sort)
+    override val decl: KDecl<KRealSort>
+        get() = ctx.mkFpToRealDecl(value.sort)
 
     override val sort: KRealSort
         get() = ctx.realSort
@@ -673,7 +701,8 @@ class KFpToIEEEBvExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<S>>
         get() = listOf(value)
 
-    override fun decl(): KDecl<KBvSort> = ctx.mkFpToIEEEBvDecl(value.sort)
+    override val decl: KDecl<KBvSort>
+        get() = ctx.mkFpToIEEEBvDecl(value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<KBvSort> = transformer.transform(this)
 
@@ -698,9 +727,8 @@ class KFpFromBvExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<out KBvSort>>
         get() = listOf(sign, exponent, significand)
 
-    override fun decl(): KDecl<S> = with(ctx) {
-        mkFpFromBvDecl(sign.sort, exponent.sort, significand.sort)
-    }
+    override val decl: KDecl<S>
+        get() = ctx.mkFpFromBvDecl(sign.sort, exponent.sort, significand.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 }
@@ -714,9 +742,8 @@ class KFpToFpExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<*>>
         get() = listOf(roundingMode, value)
 
-    override fun decl(): KDecl<S> = with(ctx) {
-        mkFpToFpDecl(sort, roundingMode.sort, value.sort)
-    }
+    override val decl: KDecl<S>
+        get() = ctx.mkFpToFpDecl(sort, roundingMode.sort, value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 }
@@ -730,9 +757,8 @@ class KRealToFpExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<*>>
         get() = listOf(roundingMode, value)
 
-    override fun decl(): KDecl<S> = with(ctx) {
-        mkRealToFpDecl(sort, roundingMode.sort, value.sort)
-    }
+    override val decl: KDecl<S>
+        get() = ctx.mkRealToFpDecl(sort, roundingMode.sort, value.sort)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 }
@@ -747,9 +773,8 @@ class KBvToFpExpr<S : KFpSort> internal constructor(
     override val args: List<KExpr<*>>
         get() = listOf(roundingMode, value)
 
-    override fun decl(): KDecl<S> = with(ctx) {
-        mkBvToFpDecl(sort, roundingMode.sort, value.sort, signed)
-    }
+    override val decl: KDecl<S>
+        get() = ctx.mkBvToFpDecl(sort, roundingMode.sort, value.sort, signed)
 
     override fun accept(transformer: KTransformerBase): KExpr<S> = transformer.transform(this)
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KFpRoundingMode.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KFpRoundingMode.kt
@@ -22,7 +22,8 @@ class KFpRoundingModeExpr(
 
     override fun decl(): KDecl<KFpRoundingModeSort> = ctx.mkFpRoundingModeDecl(value)
 
-    override fun sort(): KFpRoundingModeSort = ctx.mkFpRoundingModeSort()
+    override val sort: KFpRoundingModeSort
+        get() = ctx.mkFpRoundingModeSort()
 
     override fun accept(transformer: KTransformerBase): KExpr<KFpRoundingModeSort> = transformer.transform(this)
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KFpRoundingMode.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KFpRoundingMode.kt
@@ -20,7 +20,8 @@ class KFpRoundingModeExpr(
     override val args: List<KExpr<*>>
         get() = emptyList()
 
-    override fun decl(): KDecl<KFpRoundingModeSort> = ctx.mkFpRoundingModeDecl(value)
+    override val decl: KDecl<KFpRoundingModeSort>
+        get() = ctx.mkFpRoundingModeDecl(value)
 
     override val sort: KFpRoundingModeSort
         get() = ctx.mkFpRoundingModeSort()

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KQuantifier.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KQuantifier.kt
@@ -9,7 +9,8 @@ abstract class KQuantifier(
     val body: KExpr<KBoolSort>,
     val bounds: List<KDecl<*>>,
 ) : KExpr<KBoolSort>(ctx) {
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     abstract fun printQuantifierName(): String
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/Real.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/Real.kt
@@ -13,7 +13,8 @@ class KToIntRealExpr internal constructor(
     ctx: KContext,
     val arg: KExpr<KRealSort>
 ) : KApp<KIntSort, KExpr<KRealSort>>(ctx) {
-    override fun sort(): KIntSort = ctx.mkIntSort()
+    override val sort: KIntSort
+        get() = ctx.intSort
 
     override fun decl(): KRealToIntDecl = ctx.mkRealToIntDecl()
 
@@ -27,7 +28,8 @@ class KIsIntRealExpr internal constructor(
     ctx: KContext,
     val arg: KExpr<KRealSort>
 ) : KApp<KBoolSort, KExpr<KRealSort>>(ctx) {
-    override fun sort(): KBoolSort = ctx.mkBoolSort()
+    override val sort: KBoolSort
+        get() = ctx.boolSort
 
     override fun decl(): KRealIsIntDecl = ctx.mkRealIsIntDecl()
 
@@ -42,7 +44,8 @@ class KRealNumExpr internal constructor(
     val numerator: KIntNumExpr,
     val denominator: KIntNumExpr
 ) : KApp<KRealSort, KExpr<*>>(ctx) {
-    override fun sort(): KRealSort = ctx.mkRealSort()
+    override val sort: KRealSort
+        get() = ctx.realSort
 
     override fun decl(): KRealNumDecl = ctx.mkRealNumDecl("$numerator/$denominator")
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/Real.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/Real.kt
@@ -16,7 +16,8 @@ class KToIntRealExpr internal constructor(
     override val sort: KIntSort
         get() = ctx.intSort
 
-    override fun decl(): KRealToIntDecl = ctx.mkRealToIntDecl()
+    override val decl: KRealToIntDecl
+        get() = ctx.mkRealToIntDecl()
 
     override val args: List<KExpr<KRealSort>>
         get() = listOf(arg)
@@ -31,7 +32,8 @@ class KIsIntRealExpr internal constructor(
     override val sort: KBoolSort
         get() = ctx.boolSort
 
-    override fun decl(): KRealIsIntDecl = ctx.mkRealIsIntDecl()
+    override val decl: KRealIsIntDecl
+        get() = ctx.mkRealIsIntDecl()
 
     override val args: List<KExpr<KRealSort>>
         get() = listOf(arg)
@@ -47,7 +49,8 @@ class KRealNumExpr internal constructor(
     override val sort: KRealSort
         get() = ctx.realSort
 
-    override fun decl(): KRealNumDecl = ctx.mkRealNumDecl("$numerator/$denominator")
+    override val decl: KRealNumDecl
+        get() = ctx.mkRealNumDecl("$numerator/$denominator")
 
     override val args = emptyList<KExpr<*>>()
 

--- a/ksmt-core/src/test/kotlin/org/ksmt/ExpressionSortTest.kt
+++ b/ksmt-core/src/test/kotlin/org/ksmt/ExpressionSortTest.kt
@@ -1,0 +1,22 @@
+package org.ksmt
+
+import org.ksmt.utils.getValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ExpressionSortTest {
+
+    @Test
+    fun testDeepExpressionSort() = with(KContext()) {
+        val a by mkBv32Sort()
+        val b by mkBv32Sort()
+
+        var expr = a
+        repeat(100000) {
+            expr = mkBvAddExpr(expr, b)
+        }
+
+        assertEquals(mkBv32Sort(), expr.sort)
+    }
+
+}

--- a/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstSerializer.kt
+++ b/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstSerializer.kt
@@ -394,7 +394,7 @@ class AstSerializer(
         transform {
             writeExpr {
                 writeString(binaryStringValue)
-                writeUInt(sort().sizeBits)
+                writeUInt(sort.sizeBits)
             }
         }
     }

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
@@ -231,7 +231,7 @@ open class KZ3ExprInternalizer(
     }
 
     fun <T : KBvSort> transformBitVecValue(expr: KBitVecValue<T>) = expr.transform {
-        val sizeBits = expr.sort().sizeBits.toInt()
+        val sizeBits = expr.sort.sizeBits.toInt()
 
         when (expr) {
             is KBitVec1Value -> z3Ctx.mkBvNumeral(booleanArrayOf(expr.value))

--- a/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/BitVecTest.kt
+++ b/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/BitVecTest.kt
@@ -1,10 +1,5 @@
 package org.ksmt.solver.z3
 
-import kotlin.random.Random
-import kotlin.random.nextUInt
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -30,6 +25,11 @@ import org.ksmt.sort.KBv64Sort
 import org.ksmt.sort.KBv8Sort
 import org.ksmt.utils.mkConst
 import org.ksmt.utils.toBinary
+import kotlin.random.Random
+import kotlin.random.nextUInt
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class BitVecTest {
     private var context = KContext()
@@ -211,8 +211,8 @@ class BitVecTest {
         val negativeBv = mkBv(negativeValue, negativeSizeBits)
         val positiveBv = mkBv(positiveValue, positiveSizeBits)
 
-        val negativeSymbolicValue = negativeBv.sort().mkConst("negative_symbolic_variable")
-        val positiveSymbolicValue = positiveBv.sort().mkConst("positive_symbolic_variable")
+        val negativeSymbolicValue = negativeBv.sort.mkConst("negative_symbolic_variable")
+        val positiveSymbolicValue = positiveBv.sort.mkConst("positive_symbolic_variable")
 
         solver.assert(mkBvNotExpr(mkBvNotExpr(negativeBv)) eq negativeBv)
         solver.assert(mkBvNotExpr(negativeBv) eq negativeSymbolicValue)
@@ -224,7 +224,7 @@ class BitVecTest {
 
         val actualNegativeValue = (solver.model().eval(negativeSymbolicValue) as KBitVec64Value).numberValue.toBinary()
         val actualPositiveValue = (solver.model().eval(positiveSymbolicValue) as KBitVec64Value).numberValue.toBinary()
-        val sizeBits = negativeBv.sort().sizeBits
+        val sizeBits = negativeBv.sort.sizeBits
 
         val expectedValueTransformation = { stringValue: String ->
             stringValue
@@ -620,7 +620,7 @@ class BitVecTest {
         val value = Random.nextLong().toBv()
         val shiftSize = Random.nextInt(from = 1, until = 50).toLong().toBv()
 
-        val symbolicVariable = value.sort().mkConst("symbolicVariable")
+        val symbolicVariable = value.sort.mkConst("symbolicVariable")
 
         solver.assert(symbolicVariable eq symbolicOperation(value, shiftSize))
         solver.check()
@@ -645,7 +645,7 @@ class BitVecTest {
         val bv = Random.nextLong().toBv()
         val rotateSize = Random.nextLong(from = 1, until = 4).toBv()
 
-        val symbolicVariable = bv.sort().mkConst("symbolicVariable")
+        val symbolicVariable = bv.sort.mkConst("symbolicVariable")
 
         solver.assert(symbolicVariable eq mkBvRotateLeftExpr(bv, rotateSize))
         solver.check()
@@ -663,7 +663,7 @@ class BitVecTest {
         val bv = Random.nextLong().toBv()
         val rotateSize = Random.nextInt(from = 1, until = 4)
 
-        val symbolicVariable = bv.sort().mkConst("symbolicVariable")
+        val symbolicVariable = bv.sort.mkConst("symbolicVariable")
 
         solver.assert(symbolicVariable eq mkBvRotateLeftIndexedExpr(rotateSize, bv))
         solver.check()
@@ -681,7 +681,7 @@ class BitVecTest {
         val bv = Random.nextLong().toBv()
         val rotateSize = Random.nextLong(from = 1, until = 4).toBv()
 
-        val symbolicVariable = bv.sort().mkConst("symbolicVariable")
+        val symbolicVariable = bv.sort.mkConst("symbolicVariable")
 
         solver.assert(symbolicVariable eq mkBvRotateRightExpr(bv, rotateSize))
         solver.check()
@@ -701,7 +701,7 @@ class BitVecTest {
         val bv = Random.nextLong().toBv()
         val rotateSize = Random.nextInt(from = 1, until = 4)
 
-        val symbolicVariable = bv.sort().mkConst("symbolicVariable")
+        val symbolicVariable = bv.sort.mkConst("symbolicVariable")
 
         solver.assert(symbolicVariable eq mkBvRotateRightIndexedExpr(rotateSize, bv))
         solver.check()


### PR DESCRIPTION
### Api rework
Currently, we have two ways to compute the sort of an expression: the `.expr` extension property, defined inside the `KContext` and `KExpr.sort()` method. It is unclear, which one to use.

From now on, we have the `KExpr.sort` property and the `.sort()` is deprecated.

Same with `.decl` and `.decl()`.

### Rework caches for expression sort and decl
1. Remove the expr declaration cache, since a declaration can always be constructed in a constant time.
2. Don't cache sorts for expressions whose sort can be obtained in a constant time.
3. Don't use recursion to compute sort of deeply nested expressions (e.g. array store) to avoid `StackOverflow`.