### PR TITLE
Expression printer

### DIFF
--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprConverter.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprConverter.kt
@@ -6,6 +6,7 @@ import org.ksmt.decl.KFuncDecl
 import org.ksmt.expr.KBitVecValue
 import org.ksmt.expr.KExpr
 import org.ksmt.expr.KFpRoundingMode
+import org.ksmt.expr.printer.ExpressionPrinter
 import org.ksmt.expr.transformer.KNonRecursiveTransformer
 import org.ksmt.expr.transformer.KTransformerBase
 import org.ksmt.solver.bitwuzla.bindings.BitwuzlaBitVector
@@ -741,10 +742,10 @@ open class KBitwuzlaExprConverter(
         override val sort: KBv1Sort
             get() = ctx.bv1Sort
 
-        override fun print(builder: StringBuilder) {
-            builder.append("(toBV1 ")
-            arg.print(builder)
-            builder.append(')')
+        override fun print(printer: ExpressionPrinter) = with(printer) {
+            append("(toBV1 ")
+            append(arg)
+            append(")")
         }
 
         override fun accept(transformer: KTransformerBase): KExpr<KBv1Sort> {
@@ -757,10 +758,10 @@ open class KBitwuzlaExprConverter(
         override val sort: KBoolSort
             get() = ctx.boolSort
 
-        override fun print(builder: StringBuilder) {
-            builder.append("(toBool ")
-            arg.print(builder)
-            builder.append(')')
+        override fun print(printer: ExpressionPrinter) = with(printer) {
+            append("(toBool ")
+            append(arg)
+            append(")")
         }
 
         override fun accept(transformer: KTransformerBase): KExpr<KBoolSort> {
@@ -777,12 +778,12 @@ open class KBitwuzlaExprConverter(
         override val sort: KArraySort<ToDomain, ToRange>
             get() = ctx.mkArraySort(toDomainSort, toRangeSort)
 
-        override fun print(builder: StringBuilder) {
-            builder.append("(toArray ")
-            sort.print(builder)
-            builder.append(' ')
-            arg.print(builder)
-            builder.append(')')
+        override fun print(printer: ExpressionPrinter) = with(printer) {
+            append("(toArray ")
+            append("$sort")
+            append(" ")
+            append(arg)
+            append(")")
         }
 
         override fun accept(transformer: KTransformerBase): KExpr<KArraySort<ToDomain, ToRange>> {

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/Array.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/Array.kt
@@ -4,6 +4,7 @@ import org.ksmt.KContext
 import org.ksmt.decl.KArrayConstDecl
 import org.ksmt.decl.KDecl
 import org.ksmt.decl.KFuncDecl
+import org.ksmt.expr.printer.ExpressionPrinter
 import org.ksmt.expr.transformer.KTransformerBase
 import org.ksmt.sort.KArraySort
 import org.ksmt.sort.KSort
@@ -89,10 +90,10 @@ class KFunctionAsArray<D : KSort, R : KSort> internal constructor(
     override val sort: KArraySort<D, R>
         get() = ctx.mkArraySort(domainSort, function.sort)
 
-    override fun print(builder: StringBuilder): Unit = with(builder) {
+    override fun print(printer: ExpressionPrinter): Unit = with(printer) {
         append("(asArray ")
         append(function.name)
-        append(')')
+        append(")")
     }
 
     override fun accept(transformer: KTransformerBase): KExpr<KArraySort<D, R>> = transformer.transform(this)
@@ -108,17 +109,20 @@ class KArrayLambda<D : KSort, R : KSort> internal constructor(
     val body: KExpr<R>
 ) : KExpr<KArraySort<D, R>>(ctx) {
 
-    override fun print(builder: StringBuilder): Unit = with(builder) {
-        append("(lambda ((")
-        append(indexVarDecl.name)
-        append(' ')
+    override fun print(printer: ExpressionPrinter) {
+        val str = buildString {
+            append("(lambda ((")
+            append(indexVarDecl.name)
+            append(' ')
 
-        indexVarDecl.sort.print(this)
-        append(")) ")
+            indexVarDecl.sort.print(this)
+            append(")) ")
 
-        body.print(this)
+            body.print(this)
 
-        append(')')
+            append(')')
+        }
+        printer.append(str)
     }
 
     override fun accept(transformer: KTransformerBase): KExpr<KArraySort<D, R>> = transformer.transform(this)

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KApp.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KApp.kt
@@ -2,6 +2,8 @@ package org.ksmt.expr
 
 import org.ksmt.KContext
 import org.ksmt.decl.KDecl
+import org.ksmt.decl.KParameterizedFuncDecl
+import org.ksmt.expr.printer.ExpressionPrinter
 import org.ksmt.expr.transformer.KTransformerBase
 import org.ksmt.sort.KSort
 
@@ -14,22 +16,33 @@ abstract class KApp<T : KSort, A : KExpr<*>> internal constructor(ctx: KContext)
     @Deprecated("Use property", ReplaceWith("decl"))
     fun decl(): KDecl<T> = decl
 
-    override fun print(builder: StringBuilder): Unit = with(ctx) {
-        with(builder) {
+    override fun print(printer: ExpressionPrinter) {
+        with(printer) {
             if (args.isEmpty()) {
-                append(decl.name)
+                append(decl)
                 return
             }
 
-            append('(')
-            append(decl.name)
+            append("(")
+            append(decl)
 
             for (arg in args) {
-                append(' ')
-                arg.print(this)
+                append(" ")
+                append(arg)
             }
 
-            append(')')
+            append(")")
+        }
+    }
+
+    private fun ExpressionPrinter.append(decl: KDecl<*>) {
+        append(decl.name)
+        if (decl is KParameterizedFuncDecl) {
+            append(" (_")
+            for (param in decl.parameters) {
+                append(" $param")
+            }
+            append(")")
         }
     }
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KExpr.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KExpr.kt
@@ -2,8 +2,10 @@ package org.ksmt.expr
 
 import org.ksmt.KAst
 import org.ksmt.KContext
+import org.ksmt.expr.printer.ExpressionPrinter
 import org.ksmt.expr.transformer.KTransformerBase
 import org.ksmt.sort.KSort
+import org.ksmt.expr.printer.ExpressionPrinterWithLetBindings
 
 abstract class KExpr<T : KSort>(ctx: KContext) : KAst(ctx) {
 
@@ -31,4 +33,10 @@ abstract class KExpr<T : KSort>(ctx: KContext) : KAst(ctx) {
      * @see [computeExprSort]
      * */
     open fun sortComputationExprDependency(dependency: MutableList<KExpr<*>>) {}
+
+    override fun print(builder: StringBuilder) {
+        ExpressionPrinterWithLetBindings().print(this, builder)
+    }
+
+    abstract fun print(printer: ExpressionPrinter)
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KQuantifier.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KQuantifier.kt
@@ -2,6 +2,7 @@ package org.ksmt.expr
 
 import org.ksmt.KContext
 import org.ksmt.decl.KDecl
+import org.ksmt.expr.printer.ExpressionPrinter
 import org.ksmt.sort.KBoolSort
 
 abstract class KQuantifier(
@@ -14,21 +15,25 @@ abstract class KQuantifier(
 
     abstract fun printQuantifierName(): String
 
-    override fun print(builder: StringBuilder): Unit = with(builder) {
-        append('(')
-        append(printQuantifierName())
-        append('(')
-
-        bounds.forEach { bound ->
+    override fun print(printer: ExpressionPrinter) {
+        val str = buildString {
             append('(')
-            append(bound.name)
-            append(' ')
-            bound.sort.print(this)
+            append(printQuantifierName())
+            append('(')
+
+            bounds.forEach { bound ->
+                append('(')
+                append(bound.name)
+                append(' ')
+                bound.sort.print(this)
+                append(')')
+            }
+
+            appendLine(')')
+            body.print(this)
+            appendLine()
             append(')')
         }
-
-        append(')')
-        body.print(this)
-        append(')')
+        printer.append(str)
     }
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/printer/ExpressionPrinter.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/printer/ExpressionPrinter.kt
@@ -1,0 +1,15 @@
+package org.ksmt.expr.printer
+
+import org.ksmt.expr.KExpr
+
+interface ExpressionPrinter {
+    /**
+     * Append string as in StringBuilder.
+     * */
+    fun append(str: String)
+
+    /**
+     * Append an expression.
+     * */
+    fun append(expr: KExpr<*>)
+}

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/printer/ExpressionPrinterWithLetBindings.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/printer/ExpressionPrinterWithLetBindings.kt
@@ -1,0 +1,169 @@
+package org.ksmt.expr.printer
+
+import org.ksmt.expr.KApp
+import org.ksmt.expr.KExpr
+
+/**
+ * Print expressions non-recursively.
+ * Use let-bindings for common subexpressions to minimize result string.
+ * */
+class ExpressionPrinterWithLetBindings {
+    fun print(expr: KExpr<*>, out: StringBuilder) {
+        val resolvedExpressionPrinters = hashMapOf<KExpr<*>, SingleExpressionPrinter>()
+        val printQueue = arrayListOf<SingleExpressionPrinter>()
+        val enqueuedToPrint = hashSetOf<KExpr<*>>()
+        val hasMultipleOccurrences = hashSetOf<KExpr<*>>()
+
+        val exprStack = arrayListOf(expr)
+        while (exprStack.isNotEmpty()) {
+            val e = exprStack.removeLast()
+
+            if (e in resolvedExpressionPrinters || e in enqueuedToPrint) {
+                hasMultipleOccurrences.add(e)
+                continue
+            }
+
+            val printer = SingleExpressionPrinter(e).also { e.print(it) }
+            printQueue.add(printer)
+            enqueuedToPrint.add(e)
+
+            if (!printer.hasDependency) {
+                resolvedExpressionPrinters[e] = printer
+            } else {
+                exprStack.addAll(printer.dependency)
+            }
+        }
+
+        val letBindings = generateLetBindings(
+            resolvedExpressionPrinters = resolvedExpressionPrinters,
+            // reverse printer queue to generate lower binding indices for simpler expressions
+            unresolvedPrinters = printQueue.asReversed(),
+            hasMultipleOccurrences = hasMultipleOccurrences
+        )
+
+        while (printQueue.isNotEmpty()) {
+            val printer = printQueue.removeLast()
+            if (printer.expr in resolvedExpressionPrinters) continue
+            printer.resolveDependencies(resolvedExpressionPrinters)
+            resolvedExpressionPrinters[printer.expr] = printer
+        }
+
+        for ((_, printer) in letBindings) {
+            printer.resolveDependencies(resolvedExpressionPrinters)
+        }
+
+        val exprPrinter = resolvedExpressionPrinters.getValue(expr)
+        printToBuffer(out, letBindings, exprPrinter)
+    }
+
+    @Suppress("LoopWithTooManyJumpStatements")
+    private fun generateLetBindings(
+        resolvedExpressionPrinters: MutableMap<KExpr<*>, SingleExpressionPrinter>,
+        unresolvedPrinters: List<SingleExpressionPrinter>,
+        hasMultipleOccurrences: Set<KExpr<*>>
+    ): List<Pair<String, SingleExpressionPrinter>> {
+        val letBindings = arrayListOf<Pair<String, SingleExpressionPrinter>>()
+        val immutableResolvedPrinters = resolvedExpressionPrinters.values.toList()
+        val letBindingCandidates = immutableResolvedPrinters.asSequence() + unresolvedPrinters.asSequence()
+        for (printer in letBindingCandidates) {
+            val expr = printer.expr
+            when {
+                expr !in hasMultipleOccurrences -> continue
+                // Don't produce bindings for constants
+                expr is KApp<*, *> && expr.args.isEmpty() -> continue
+                else -> {
+                    val bindingIdx = letBindings.size + 1
+                    val bindingName = "e!$bindingIdx"
+
+                    letBindings += bindingName to printer
+                    resolvedExpressionPrinters[expr] = SingleExpressionPrinter(expr).apply {
+                        append(bindingName)
+                    }
+                }
+            }
+        }
+        return letBindings
+    }
+
+    private fun printToBuffer(
+        out: StringBuilder,
+        letBindings: List<Pair<String, SingleExpressionPrinter>>,
+        exprPrinter: SingleExpressionPrinter
+    ) {
+        if (letBindings.isNotEmpty()) {
+            out.appendLine("(let (")
+            for ((name, bindingPrinter) in letBindings) {
+                out.append('(')
+                out.append(name)
+                out.append(' ')
+                bindingPrinter.printToBuffer(out)
+                out.appendLine(')')
+            }
+            out.appendLine(')')
+        }
+
+        exprPrinter.printToBuffer(out)
+
+        if (letBindings.isNotEmpty()) {
+            out.append(')')
+        }
+    }
+
+    private class SingleExpressionPrinter(val expr: KExpr<*>) : ExpressionPrinter {
+        /**
+         * Actual type: String | KExpr<*>
+         * Type after dependency resolution: String | SingleExpressionPrinter
+         * */
+        private val parts = arrayListOf<Any>()
+        var hasDependency = false
+            private set
+
+        val dependency: List<KExpr<*>>
+            get() = if (hasDependency) parts.filterIsInstance<KExpr<*>>() else emptyList()
+
+        override fun append(str: String) {
+            parts.add(str)
+        }
+
+        override fun append(expr: KExpr<*>) {
+            parts.add(expr)
+            hasDependency = true
+        }
+
+        fun resolveDependencies(printedExpressions: Map<KExpr<*>, SingleExpressionPrinter>) {
+            if (!hasDependency) return
+
+            val currentParts = parts.toList()
+            parts.clear()
+
+            for (part in currentParts) {
+                if (part !is KExpr<*>) {
+                    parts.add(part)
+                    continue
+                }
+
+                val printer = printedExpressions[part] ?: error("Printer failed")
+                check(!printer.hasDependency) { "Printer has unresolved parts" }
+
+                parts.add(printer)
+            }
+
+            hasDependency = false
+        }
+
+        fun printToBuffer(buffer: StringBuilder) {
+            val printerStack = arrayListOf<Any>(this)
+            while (printerStack.isNotEmpty()) {
+                when (val element = printerStack.removeLast()) {
+                    is String -> buffer.append(element)
+                    is SingleExpressionPrinter -> {
+                        check(!element.hasDependency) { "Printer has unresolved parts" }
+                        printerStack.addAll(element.parts.asReversed())
+                    }
+                    else -> error("Unexpected printer part")
+                }
+            }
+        }
+    }
+
+}

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/KBvExprSimplifier.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/KBvExprSimplifier.kt
@@ -57,6 +57,7 @@ import org.ksmt.expr.KBvZeroExtensionExpr
 import org.ksmt.expr.KEqExpr
 import org.ksmt.expr.KExpr
 import org.ksmt.expr.KIteExpr
+import org.ksmt.expr.printer.ExpressionPrinter
 import org.ksmt.expr.transformer.KTransformerBase
 import org.ksmt.sort.KBoolSort
 import org.ksmt.sort.KBv1Sort
@@ -1697,13 +1698,15 @@ interface KBvExprSimplifier : KExprSimplifierBase {
             return transformer.transform(this)
         }
 
-        override fun print(builder: StringBuilder): Unit = with(builder) {
-            append("(concat")
-            for (arg in args) {
-                append(" ")
-                arg.print(this)
+        override fun print(printer: ExpressionPrinter) {
+            with(printer) {
+                append("(concat")
+                for (arg in args) {
+                    append(" ")
+                    append(arg)
+                }
+                append(")")
             }
-            append(")")
         }
     }
 


### PR DESCRIPTION
1. Don't use recursion during expression printing to avoid StackOverflow. 
2. Use let bindings (as in SMT-LIB) for shared subexpressions to minimize the resulting string.

Example:
```
(let (
(e!1 (select c_#memory_int c_~#ln2LO_exp~0.base))
(e!2 (concat (select e!1 (bvadd c_~#ln2LO_exp~0.offset #b00000000000000000000000000000100)) (select e!1 c_~#ln2LO_exp~0.offset)))
)
(eq c___ieee754_exp_~lo~0_primed (fp.mul c_currentRoundingMode c___ieee754_exp_~t~0_primed (fp.to_fp (extract (_ 63 63) e!2) (extract (_ 62 52) e!2) (extract (_ 51 0) e!2)))))
```