### PR TITLE
Reduce ksmt-runner dependencies

### DIFF
--- a/ksmt-runner/build.gradle.kts
+++ b/ksmt-runner/build.gradle.kts
@@ -23,8 +23,6 @@ kotlin {
 
 dependencies {
     implementation(project(":ksmt-core"))
-    implementation(project(":ksmt-z3"))
-    implementation(project(":ksmt-bitwuzla"))
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
 
@@ -34,6 +32,8 @@ dependencies {
     rdgenModelsCompileClasspath("com.jetbrains.rd:rd-gen:2022.3.2")
 
     testImplementation(kotlin("test"))
+    testImplementation(project(":ksmt-z3"))
+    testImplementation(project(":ksmt-bitwuzla"))
 }
 
 val generateModels = tasks.register<RdGenTask>("generateProtocolModels") {

--- a/ksmt-runner/src/main/kotlin/org/ksmt/solver/runner/KSolverRunnerManager.kt
+++ b/ksmt-runner/src/main/kotlin/org/ksmt/solver/runner/KSolverRunnerManager.kt
@@ -8,11 +8,8 @@ import org.ksmt.runner.core.KsmtWorkerFactory
 import org.ksmt.runner.core.KsmtWorkerPool
 import org.ksmt.runner.core.RdServer
 import org.ksmt.runner.models.generated.SolverProtocolModel
-import org.ksmt.runner.models.generated.SolverType
 import org.ksmt.solver.KSolver
 import org.ksmt.solver.KSolverException
-import org.ksmt.solver.bitwuzla.KBitwuzlaSolver
-import org.ksmt.solver.z3.KZ3Solver
 import kotlin.reflect.KClass
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -45,19 +42,12 @@ class KSolverRunnerManager(
         if (workers.lifetime.isNotAlive) {
             throw KSolverException("Solver runner manager is terminated")
         }
-        val solverType = solverTypes[solver] ?: error("Unknown solver type: $solver")
+        val solverType = solver.solverType
         val worker = workers.getOrCreateFreeWorker()
         worker.astSerializationCtx.initCtx(ctx)
         worker.lifetime.onTermination { worker.astSerializationCtx.resetCtx() }
         return KSolverRunner(hardTimeout, worker).also {
             it.initSolver(solverType)
         }
-    }
-
-    companion object {
-        private val solverTypes = mapOf(
-            KZ3Solver::class to SolverType.Z3,
-            KBitwuzlaSolver::class to SolverType.Bitwuzla
-        )
     }
 }

--- a/ksmt-runner/src/main/kotlin/org/ksmt/solver/runner/KSolverWorkerProcess.kt
+++ b/ksmt-runner/src/main/kotlin/org/ksmt/solver/runner/KSolverWorkerProcess.kt
@@ -12,13 +12,10 @@ import org.ksmt.runner.models.generated.ModelFuncInterpEntry
 import org.ksmt.runner.models.generated.ModelResult
 import org.ksmt.runner.models.generated.ReasonUnknownResult
 import org.ksmt.runner.models.generated.SolverProtocolModel
-import org.ksmt.runner.models.generated.SolverType
 import org.ksmt.runner.models.generated.UnsatCoreResult
 import org.ksmt.runner.models.generated.solverProtocolModel
 import org.ksmt.runner.serializer.AstSerializationCtx
 import org.ksmt.solver.KSolver
-import org.ksmt.solver.bitwuzla.KBitwuzlaSolver
-import org.ksmt.solver.z3.KZ3Solver
 import org.ksmt.sort.KBoolSort
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -43,10 +40,7 @@ class KSolverWorkerProcess : ChildProcessBase<SolverProtocolModel>() {
             check(workerCtx == null) { "Solver is initialized" }
             workerCtx = KContext()
             astSerializationCtx.initCtx(ctx)
-            workerSolver = when (params.type) {
-                SolverType.Z3 -> KZ3Solver(ctx)
-                SolverType.Bitwuzla -> KBitwuzlaSolver(ctx)
-            }
+            workerSolver = params.type.createInstance(ctx)
         }
         deleteSolver.measureExecutionForTermination {
             solver.close()

--- a/ksmt-runner/src/main/kotlin/org/ksmt/solver/runner/SolverUtils.kt
+++ b/ksmt-runner/src/main/kotlin/org/ksmt/solver/runner/SolverUtils.kt
@@ -1,0 +1,34 @@
+package org.ksmt.solver.runner
+
+import org.ksmt.KContext
+import org.ksmt.runner.models.generated.SolverType
+import org.ksmt.solver.KSolver
+import kotlin.reflect.KClass
+
+private const val KSMT_SOLVER_PACKAGE = "org.ksmt.solver"
+private const val Z3_SOLVER_CLASS_NAME = "$KSMT_SOLVER_PACKAGE.z3.KZ3Solver"
+private const val BITWUZLA_SOLVER_CLASS_NAME = "$KSMT_SOLVER_PACKAGE.bitwuzla.KBitwuzlaSolver"
+
+val KClass<out KSolver>.solverType: SolverType
+    get() = when (qualifiedName) {
+        Z3_SOLVER_CLASS_NAME -> SolverType.Z3
+        BITWUZLA_SOLVER_CLASS_NAME -> SolverType.Bitwuzla
+        else -> error("Unsupported solver: ${this.qualifiedName}")
+    }
+
+private val z3SolverConstructor: (KContext) -> KSolver by lazy {
+    val cls = Class.forName(Z3_SOLVER_CLASS_NAME)
+    val ctor = cls.getConstructor(KContext::class.java)
+    ({ ctx: KContext -> ctor.newInstance(ctx) as KSolver })
+}
+
+private val bitwuzlaSolverConstructor: (KContext) -> KSolver by lazy {
+    val cls = Class.forName(BITWUZLA_SOLVER_CLASS_NAME)
+    val ctor = cls.getConstructor(KContext::class.java)
+    ({ ctx: KContext -> ctor.newInstance(ctx) as KSolver })
+}
+
+fun SolverType.createInstance(ctx: KContext): KSolver = when (this) {
+    SolverType.Z3 -> z3SolverConstructor(ctx)
+    SolverType.Bitwuzla -> bitwuzlaSolverConstructor(ctx)
+}

--- a/ksmt-runner/src/test/kotlin/org/ksmt/solver/runner/IncrementalApiTest.kt
+++ b/ksmt-runner/src/test/kotlin/org/ksmt/solver/runner/IncrementalApiTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.ksmt.KContext
+import org.ksmt.runner.models.generated.SolverType
 import org.ksmt.solver.KSolver
 import org.ksmt.solver.KSolverStatus
 import org.ksmt.solver.z3.KZ3Solver
@@ -119,5 +120,11 @@ class IncrementalApiTest {
         val status = solver.checkWithAssumptions(emptyList(), timeout = 1.milliseconds)
         assertEquals(KSolverStatus.UNKNOWN, status)
         assertEquals("timeout", solver.reasonOfUnknown())
+    }
+
+    @Test
+    fun testSolverInstanceCreation(): Unit = with(context){
+        SolverType.Z3.createInstance(this)
+        SolverType.Bitwuzla.createInstance(this)
     }
 }


### PR DESCRIPTION
Remove all solvers from ksmt-runner dependencies.
Before that, in case when the user is using only `ksmt-z3` and  `ksmt-runner`, all other solvers, e.g. `ksmt-bitwuzla`, will also be included. 