### PR TITLE
Pull from lfs before jitpack build

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+before_install:
+  - git lfs pull --exclude "ksmt-test/testData/benchmarks.zip"


### PR DESCRIPTION
Currently gradle build fails on JitPack because `*.zip` archives with Bitwuzla natives are stored in lfs.