### PR TITLE
Bv and fp optimization

### DIFF
--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprConverter.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprConverter.kt
@@ -799,8 +799,12 @@ open class KBitwuzlaExprConverter(
          * (toBv x) -> (ite x #b1 #b0)
          * */
         fun transform(expr: BoolToBv1AdapterExpr): KExpr<KBv1Sort> = with(ctx) {
-            transformExprAfterTransformed(expr, listOf(expr.arg)) { transformedArg ->
-                mkIte(transformedArg.single(), bv1Sort.trueValue(), bv1Sort.falseValue())
+            transformExprAfterTransformed(expr, listOf(expr.arg)) { (transformedArg) ->
+                when (transformedArg) {
+                    trueExpr -> bv1Sort.trueValue()
+                    falseExpr -> bv1Sort.falseValue()
+                    else -> mkIte(transformedArg, bv1Sort.trueValue(), bv1Sort.falseValue())
+                }
             }
         }
 
@@ -809,8 +813,12 @@ open class KBitwuzlaExprConverter(
          * (toBool x) -> (ite (x == #b1) true false)
          * */
         fun transform(expr: Bv1ToBoolAdapterExpr): KExpr<KBoolSort> = with(ctx) {
-            transformExprAfterTransformed(expr, listOf(expr.arg)) { transformedArg ->
-                mkIte(transformedArg.single() eq bv1Sort.trueValue(), trueExpr, falseExpr)
+            transformExprAfterTransformed(expr, listOf(expr.arg)) { (transformedArg) ->
+                when (transformedArg) {
+                    bv1Sort.trueValue() -> trueExpr
+                    bv1Sort.falseValue() -> falseExpr
+                    else -> mkIte(transformedArg eq bv1Sort.trueValue(), trueExpr, falseExpr)
+                }
             }
         }
 

--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprInternalizer.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprInternalizer.kt
@@ -344,7 +344,7 @@ open class KBitwuzlaExprInternalizer(
             Native.bitwuzlaMkBvValue(
                 bitwuzlaCtx.bitwuzla,
                 sort.internalizeSort(),
-                binaryStringValue,
+                stringValue,
                 BitwuzlaBVBase.BITWUZLA_BV_BASE_BIN
             ).also { bitwuzlaCtx.saveInternalizedValue(expr, it) }
         }

--- a/ksmt-core/build.gradle.kts
+++ b/ksmt-core/build.gradle.kts
@@ -5,7 +5,8 @@ plugins {
 }
 
 dependencies {
-
+    testImplementation(project(":ksmt-z3"))
+    testImplementation("org.junit.jupiter", "junit-jupiter-params", "5.8.2")
 }
 
 tasks.withType<KotlinCompile> {

--- a/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
@@ -245,6 +245,7 @@ import org.ksmt.expr.KBitVec32Value
 import org.ksmt.expr.KBitVec64Value
 import org.ksmt.expr.KBitVec8Value
 import org.ksmt.expr.KBitVecCustomValue
+import org.ksmt.expr.KBitVecNumberValue
 import org.ksmt.expr.KBvRotateLeftIndexedExpr
 import org.ksmt.expr.KBvRotateRightIndexedExpr
 import org.ksmt.expr.KBvSubNoUnderflowExpr
@@ -298,8 +299,12 @@ import org.ksmt.utils.extractExponent
 import org.ksmt.utils.extractSignificand
 import org.ksmt.utils.getHalfPrecisionExponent
 import org.ksmt.utils.halfPrecisionSignificand
+import org.ksmt.utils.normalizeValue
+import org.ksmt.utils.powerOfTwo
 import org.ksmt.utils.signBit
-import org.ksmt.utils.toBinary
+import org.ksmt.utils.toBigInteger
+import org.ksmt.utils.toULongValue
+import org.ksmt.utils.toUnsignedBigInteger
 import org.ksmt.utils.uncheckedCast
 
 @Suppress("TooManyFunctions", "LargeClass", "unused")
@@ -830,7 +835,7 @@ open class KContext : AutoCloseable {
     private val bv16Cache = mkClosableCache { value: Short -> KBitVec16Value(this, value) }
     private val bv32Cache = mkClosableCache { value: Int -> KBitVec32Value(this, value) }
     private val bv64Cache = mkClosableCache { value: Long -> KBitVec64Value(this, value) }
-    private val bvCache = mkClosableCache { value: String, sizeBits: UInt ->
+    private val bvCache = mkClosableCache { value: BigInteger, sizeBits: UInt ->
         KBitVecCustomValue(this, value, sizeBits)
     }
 
@@ -879,6 +884,9 @@ open class KContext : AutoCloseable {
     fun <T : KBvSort> Long.toBv(sort: T): KBitVecValue<T> = mkBv(this, sort)
     fun ULong.toBv(): KBitVec64Value = mkBv(toLong())
 
+    fun mkBv(value: BigInteger, sizeBits: UInt): KBitVecValue<KBvSort> = mkBv(value as Number, sizeBits)
+    fun <T : KBvSort> mkBv(value: BigInteger, sort: T): KBitVecValue<T> = mkBv(value as Number, sort)
+
     /**
      * Constructs a bit vector from the given [value] containing of [sizeBits] bits.
      *
@@ -889,10 +897,8 @@ open class KContext : AutoCloseable {
      * binary representation of the [value] will be padded from the start with its sign bit.
      */
     private fun mkBv(value: Number, sizeBits: UInt): KBitVecValue<KBvSort> {
-        val binaryString = value.toBinary().takeLast(sizeBits.toInt())
-        val paddedString = binaryString.padStart(sizeBits.toInt(), binaryString.first())
-
-        return mkBv(paddedString, sizeBits)
+        val bigIntValue = value.toBigInteger().normalizeValue(sizeBits)
+        return mkBvFromUnsignedBigInteger(bigIntValue, sizeBits)
     }
 
     private fun <T : KBvSort> mkBv(value: Number, sort: T): KBitVecValue<T> =
@@ -903,21 +909,30 @@ open class KContext : AutoCloseable {
      * Binary representation of the [value] will be padded from the start with 0.
      */
     private fun mkBvUnsigned(value: Number, sizeBits: UInt): KBitVecValue<KBvSort> {
-        val binaryString = value.toBinary().takeLast(sizeBits.toInt())
-        val paddedString = binaryString.padStart(sizeBits.toInt(), '0')
-
-        return mkBv(paddedString, sizeBits)
+        val bigIntValue = value.toUnsignedBigInteger().normalizeValue(sizeBits)
+        return mkBv(bigIntValue, sizeBits)
     }
 
     private fun Number.toBv(sizeBits: UInt) = mkBv(this, sizeBits)
 
-    fun mkBv(value: String, sizeBits: UInt): KBitVecValue<KBvSort> = when (sizeBits.toInt()) {
-        1 -> mkBv(value.toUInt(radix = 2).toInt() != 0).cast()
-        Byte.SIZE_BITS -> mkBv(value.toUByte(radix = 2).toByte()).cast()
-        Short.SIZE_BITS -> mkBv(value.toUShort(radix = 2).toShort()).cast()
-        Int.SIZE_BITS -> mkBv(value.toUInt(radix = 2).toInt()).cast()
-        Long.SIZE_BITS -> mkBv(value.toULong(radix = 2).toLong()).cast()
-        else -> bvCache.createIfContextActive(value, sizeBits)
+    fun mkBv(value: String, sizeBits: UInt): KBitVecValue<KBvSort> =
+        mkBv(value.toBigInteger(radix = 2), sizeBits)
+
+    private fun mkBvFromUnsignedBigInteger(
+        value: BigInteger,
+        sizeBits: UInt
+    ): KBitVecValue<KBvSort> {
+        require(value.signum() >= 0) {
+            "Unsigned value required, but $value provided"
+        }
+        return when (sizeBits.toInt()) {
+            1 -> mkBv(value != BigInteger.ZERO).cast()
+            Byte.SIZE_BITS -> mkBv(value.toByte()).cast()
+            Short.SIZE_BITS -> mkBv(value.toShort()).cast()
+            Int.SIZE_BITS -> mkBv(value.toInt()).cast()
+            Long.SIZE_BITS -> mkBv(value.toLong()).cast()
+            else -> bvCache.createIfContextActive(value, sizeBits)
+        }
     }
 
     private val bvNotExprCache = mkClosableCache { value: KExpr<KBvSort> -> KBvNotExpr(this, value) }
@@ -1494,7 +1509,12 @@ open class KContext : AutoCloseable {
         signBit
     )
 
-    private fun KBitVecValue<*>.longValue() = stringValue.toULong(radix = 2).toLong()
+    private fun KBitVecValue<*>.longValue() = when (this) {
+        is KBitVecNumberValue<*, *> -> numberValue.toULongValue().toLong()
+        is KBitVecCustomValue -> value.longValueExact()
+        is KBitVec1Value -> if (value) 1L else 0L
+        else -> stringValue.toULong(radix = 2).toLong()
+    }
 
     @Suppress("MagicNumber")
     private fun constructFp16Number(exponent: Long, significand: Long, intSignBit: Int): Float {
@@ -1722,10 +1742,10 @@ open class KContext : AutoCloseable {
     }
 
     private fun fpTopExponentUnbiased(sort: KFpSort): KBitVecValue<*> =
-        mkBv("1" + "0".repeat(sort.exponentBits.toInt() - 1), sort.exponentBits)
+        mkBv(powerOfTwo(sort.exponentBits), sort.exponentBits)
 
     private fun fpZeroExponentUnbiased(sort: KFpSort): KBitVecValue<*> =
-        mkBv("1" + "0".repeat(sort.exponentBits.toInt() - 2) + "1", sort.exponentBits)
+        mkBv(powerOfTwo(sort.exponentBits) + BigInteger.ONE, sort.exponentBits)
 
     private val roundingModeCache = mkClosableCache { value: KFpRoundingMode ->
         KFpRoundingModeExpr(this, value)
@@ -2351,7 +2371,7 @@ open class KContext : AutoCloseable {
     private val bv16DeclCache = mkClosableCache { value: Short -> KBitVec16ValueDecl(this, value) }
     private val bv32DeclCache = mkClosableCache { value: Int -> KBitVec32ValueDecl(this, value) }
     private val bv64DeclCache = mkClosableCache { value: Long -> KBitVec64ValueDecl(this, value) }
-    private val bvCustomSizeDeclCache = mkClosableCache { value: String, sizeBits: UInt ->
+    private val bvCustomSizeDeclCache = mkClosableCache { value: BigInteger, sizeBits: UInt ->
         KBitVecCustomSizeValueDecl(this, value, sizeBits)
     }
 
@@ -2360,15 +2380,8 @@ open class KContext : AutoCloseable {
     fun mkBvDecl(value: Short): KDecl<KBv16Sort> = bv16DeclCache.createIfContextActive(value)
     fun mkBvDecl(value: Int): KDecl<KBv32Sort> = bv32DeclCache.createIfContextActive(value)
     fun mkBvDecl(value: Long): KDecl<KBv64Sort> = bv64DeclCache.createIfContextActive(value)
-
-    fun mkBvDecl(value: String, sizeBits: UInt): KDecl<KBvSort> = when (sizeBits.toInt()) {
-        1 -> mkBvDecl(value.toUInt(radix = 2).toInt() != 0).cast()
-        Byte.SIZE_BITS -> mkBvDecl(value.toUByte(radix = 2).toByte()).cast()
-        Short.SIZE_BITS -> mkBvDecl(value.toUShort(radix = 2).toShort()).cast()
-        Int.SIZE_BITS -> mkBvDecl(value.toUInt(radix = 2).toInt()).cast()
-        Long.SIZE_BITS -> mkBvDecl(value.toULong(radix = 2).toLong()).cast()
-        else -> bvCustomSizeDeclCache.createIfContextActive(value, sizeBits).cast()
-    }
+    fun mkBvDecl(value: BigInteger, size: UInt): KDecl<KBvSort> =
+        bvCustomSizeDeclCache.createIfContextActive(value, size)
 
     private val bvNotDeclCache = mkClosableCache { sort: KBvSort -> KBvNotDecl(this, sort) }
     fun <T : KBvSort> mkBvNotDecl(sort: T): KBvNotDecl<T> = bvNotDeclCache.createIfContextActive(sort).cast()

--- a/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
@@ -1742,10 +1742,10 @@ open class KContext : AutoCloseable {
     }
 
     private fun fpTopExponentUnbiased(sort: KFpSort): KBitVecValue<*> =
-        mkBv(powerOfTwo(sort.exponentBits), sort.exponentBits)
+        mkBv(powerOfTwo(sort.exponentBits - 1u), sort.exponentBits)
 
     private fun fpZeroExponentUnbiased(sort: KFpSort): KBitVecValue<*> =
-        mkBv(powerOfTwo(sort.exponentBits) + BigInteger.ONE, sort.exponentBits)
+        mkBv(powerOfTwo(sort.exponentBits - 1u) + BigInteger.ONE, sort.exponentBits)
 
     private val roundingModeCache = mkClosableCache { value: KFpRoundingMode ->
         KFpRoundingModeExpr(this, value)

--- a/ksmt-core/src/main/kotlin/org/ksmt/decl/KBitVecExprsDecl.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/decl/KBitVecExprsDecl.kt
@@ -12,6 +12,7 @@ import org.ksmt.sort.KBoolSort
 import org.ksmt.sort.KBv1Sort
 import org.ksmt.sort.KIntSort
 import org.ksmt.utils.toBinary
+import java.math.BigInteger
 
 abstract class KBitVecValueDecl<T : KBvSort> internal constructor(
     ctx: KContext,
@@ -72,10 +73,14 @@ class KBitVec64ValueDecl internal constructor(
 
 class KBitVecCustomSizeValueDecl internal constructor(
     ctx: KContext,
-    value: String,
+    val bigIntValue: BigInteger,
     sizeBits: UInt
-) : KBitVecValueDecl<KBvSort>(ctx, value, ctx.mkBvSort(sizeBits)) {
-    override fun apply(args: List<KExpr<*>>): KApp<KBvSort, *> = ctx.mkBv(value, sort.sizeBits)
+) : KBitVecValueDecl<KBvSort>(
+    ctx,
+    value = bigIntValue.toBinary(sizeBits),
+    ctx.mkBvSort(sizeBits)
+) {
+    override fun apply(args: List<KExpr<*>>): KApp<KBvSort, *> = ctx.mkBv(bigIntValue, sort.sizeBits)
 
     override fun <R> accept(visitor: KDeclVisitor<R>): R = visitor.visit(this)
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KBitVecExprs.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KBitVecExprs.kt
@@ -27,7 +27,8 @@ class KBitVec1Value internal constructor(
 ) : KBitVecValue<KBv1Sort>(ctx) {
     override fun accept(transformer: KTransformerBase): KExpr<KBv1Sort> = transformer.transform(this)
 
-    override val stringValue: String = if (value) "1" else "0"
+    override val stringValue: String
+        get() = if (value) "1" else "0"
 
     override val decl: KDecl<KBv1Sort>
         get() = ctx.mkBvDecl(value)
@@ -40,7 +41,8 @@ abstract class KBitVecNumberValue<S : KBvSort, N : Number>(
     ctx: KContext,
     val numberValue: N
 ) : KBitVecValue<S>(ctx) {
-    override val stringValue: String = numberValue.toBinary()
+    override val stringValue: String
+        get() = numberValue.toBinary()
 }
 
 class KBitVec8Value internal constructor(
@@ -97,7 +99,7 @@ class KBitVec64Value internal constructor(
 
 class KBitVecCustomValue internal constructor(
     ctx: KContext,
-    val binaryStringValue: String,
+    private val binaryStringValue: String,
     private val sizeBits: UInt
 ) : KBitVecValue<KBvSort>(ctx) {
     init {
@@ -109,7 +111,8 @@ class KBitVecCustomValue internal constructor(
 
     override fun accept(transformer: KTransformerBase): KExpr<KBvSort> = transformer.transform(this)
 
-    override val stringValue: String = binaryStringValue
+    override val stringValue: String
+        get() = binaryStringValue
 
     override val decl: KDecl<KBvSort>
         get() = ctx.mkBvDecl(binaryStringValue, sizeBits)

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KBitVecExprs.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KBitVecExprs.kt
@@ -12,6 +12,7 @@ import org.ksmt.sort.KBv8Sort
 import org.ksmt.sort.KBvSort
 import org.ksmt.sort.KIntSort
 import org.ksmt.utils.toBinary
+import java.math.BigInteger
 
 abstract class KBitVecValue<S : KBvSort>(
     ctx: KContext
@@ -99,23 +100,17 @@ class KBitVec64Value internal constructor(
 
 class KBitVecCustomValue internal constructor(
     ctx: KContext,
-    private val binaryStringValue: String,
-    private val sizeBits: UInt
+    val value: BigInteger,
+    val sizeBits: UInt
 ) : KBitVecValue<KBvSort>(ctx) {
-    init {
-        require(binaryStringValue.length.toUInt() == sizeBits) {
-            "Provided string $binaryStringValue consist of ${binaryStringValue.length} " +
-                    "symbols, but $sizeBits were expected"
-        }
-    }
 
     override fun accept(transformer: KTransformerBase): KExpr<KBvSort> = transformer.transform(this)
 
     override val stringValue: String
-        get() = binaryStringValue
+        get() = value.toBinary(sizeBits)
 
     override val decl: KDecl<KBvSort>
-        get() = ctx.mkBvDecl(binaryStringValue, sizeBits)
+        get() = ctx.mkBvDecl(value, sizeBits)
 
     override val sort: KBvSort
         get() = ctx.mkBvSort(sizeBits)

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/KBvExprSimplifier.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/KBvExprSimplifier.kt
@@ -71,7 +71,7 @@ import org.ksmt.utils.BvUtils.bvMaxValueUnsigned
 import org.ksmt.utils.BvUtils.bvMinValueSigned
 import org.ksmt.utils.BvUtils.bvOne
 import org.ksmt.utils.BvUtils.bvZero
-import org.ksmt.utils.BvUtils.intValueOrNull
+import org.ksmt.utils.BvUtils.bigIntValue
 import org.ksmt.utils.BvUtils.minus
 import org.ksmt.utils.BvUtils.plus
 import org.ksmt.utils.BvUtils.powerOfTwoOrNull
@@ -90,7 +90,9 @@ import org.ksmt.utils.BvUtils.unsignedDivide
 import org.ksmt.utils.BvUtils.unsignedLessOrEqual
 import org.ksmt.utils.BvUtils.unsignedRem
 import org.ksmt.utils.cast
+import org.ksmt.utils.toBigInteger
 import org.ksmt.utils.uncheckedCast
+import java.math.BigInteger
 
 @Suppress(
     "LargeClass",
@@ -944,14 +946,19 @@ interface KBvExprSimplifier : KExprSimplifierBase {
             }
 
             // (bvshl x shift) ==> (concat (extract [size-1-shift:0] x) 0.[shift].0)
-            val intShiftValue = shiftValue.intValueOrNull()
-            if (intShiftValue != null && intShiftValue >= 0) {
+            val intShiftValue = shiftValue.bigIntValue()
+            if (intShiftValue >= BigInteger.ZERO && intShiftValue <= Int.MAX_VALUE.toBigInteger()) {
                 return@simplifyApp rewrite(
                     auxExpr {
                         KBvConcatExpr(
                             ctx,
-                            KBvExtractExpr(ctx, high = size.toInt() - 1 - intShiftValue, low = 0, arg.uncheckedCast()),
-                            bvZero(intShiftValue.toUInt()).uncheckedCast()
+                            KBvExtractExpr(
+                                ctx,
+                                high = size.toInt() - 1 - intShiftValue.toInt(),
+                                low = 0,
+                                arg.uncheckedCast()
+                            ),
+                            bvZero(intShiftValue.toInt().toUInt()).uncheckedCast()
                         ).uncheckedCast()
                     }
                 )
@@ -1001,15 +1008,15 @@ interface KBvExprSimplifier : KExprSimplifierBase {
                 }
 
                 // (bvlshr x shift) ==> (concat 0.[shift].0 (extract [size-1:shift] x))
-                val intShiftValue = shiftValue.intValueOrNull()
-                if (intShiftValue != null && intShiftValue >= 0) {
+                val intShiftValue = shiftValue.bigIntValue()
+                if (intShiftValue >= BigInteger.ZERO && intShiftValue <= Int.MAX_VALUE.toBigInteger()) {
                     return@simplifyApp rewrite(
                         auxExpr {
-                            val lhs = bvZero(intShiftValue.toUInt())
+                            val lhs = bvZero(intShiftValue.toInt().toUInt())
                             val rhs = KBvExtractExpr(
                                 ctx,
                                 high = size.toInt() - 1,
-                                low = intShiftValue,
+                                low = intShiftValue.toInt(),
                                 arg.uncheckedCast()
                             )
                             KBvConcatExpr(ctx, lhs.uncheckedCast(), rhs).uncheckedCast()
@@ -1092,6 +1099,16 @@ interface KBvExprSimplifier : KExprSimplifierBase {
         return@simplifyApp rotateLeft(arg, size, expr.rotationNumber)
     }
 
+    override fun <T : KBvSort> transform(expr: KBvRotateLeftExpr<T>): KExpr<T> = simplifyApp(expr) { (arg, rotation) ->
+        if (rotation is KBitVecValue<T>) {
+            val size = expr.sort.sizeBits.toInt()
+            val intValue = rotation.bigIntValue()
+            val rotationValue = intValue.remainder(size.toBigInteger()).toInt()
+            return@simplifyApp rotateLeft(arg, size, rotationValue)
+        }
+        return@simplifyApp mkBvRotateLeftExpr(arg, rotation)
+    }
+
     // (rotateRight a x) ==> (rotateLeft a (- size x))
     override fun <T : KBvSort> transform(expr: KBvRotateRightIndexedExpr<T>): KExpr<T> = simplifyApp(expr) { (arg) ->
         val size = expr.sort.sizeBits.toInt()
@@ -1099,8 +1116,18 @@ interface KBvExprSimplifier : KExprSimplifierBase {
         return@simplifyApp rotateLeft(arg, size, rotationNumber = size - rotation)
     }
 
+    override fun <T : KBvSort> transform(expr: KBvRotateRightExpr<T>): KExpr<T> = simplifyApp(expr) { (arg, rotation) ->
+        if (rotation is KBitVecValue<T>) {
+            val size = expr.sort.sizeBits.toInt()
+            val intValue = rotation.bigIntValue()
+            val rotationValue = intValue.remainder(size.toBigInteger()).toInt()
+            return@simplifyApp rotateLeft(arg, size, rotationNumber = size - rotationValue)
+        }
+        return@simplifyApp mkBvRotateRightExpr(arg, rotation)
+    }
+
     fun <T : KBvSort> rotateLeft(arg: KExpr<T>, size: Int, rotationNumber: Int): KExpr<T> = with(ctx) {
-        val rotation = rotationNumber % size
+        val rotation = rotationNumber.mod(size)
 
         if (rotation == 0 || size == 1) {
             return arg
@@ -1113,34 +1140,6 @@ interface KBvExprSimplifier : KExprSimplifierBase {
                 KBvConcatExpr(ctx, lhs, rhs).uncheckedCast()
             }
         )
-    }
-
-    override fun <T : KBvSort> transform(expr: KBvRotateLeftExpr<T>): KExpr<T> = simplifyApp(expr) { (arg, rotation) ->
-        if (rotation is KBitVecValue<T>) {
-            val intValue = rotation.intValueOrNull()
-            if (intValue != null && intValue >= 0) {
-                return@simplifyApp rewrite(
-                    auxExpr {
-                        KBvRotateLeftIndexedExpr(ctx, intValue, arg)
-                    }
-                )
-            }
-        }
-        return@simplifyApp mkBvRotateLeftExpr(arg, rotation)
-    }
-
-    override fun <T : KBvSort> transform(expr: KBvRotateRightExpr<T>): KExpr<T> = simplifyApp(expr) { (arg, rotation) ->
-        if (rotation is KBitVecValue<T>) {
-            val intValue = rotation.intValueOrNull()
-            if (intValue != null && intValue >= 0) {
-                return@simplifyApp rewrite(
-                    auxExpr {
-                        KBvRotateRightIndexedExpr(ctx, intValue, arg)
-                    }
-                )
-            }
-        }
-        return@simplifyApp mkBvRotateRightExpr(arg, rotation)
     }
 
     override fun <T : KBvSort> transform(expr: KBvAddNoOverflowExpr<T>): KExpr<KBoolSort> =

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/KBvExprSimplifier.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/KBvExprSimplifier.kt
@@ -1297,7 +1297,7 @@ interface KBvExprSimplifier : KExprSimplifierBase {
             val lhsSign = lhsValue.stringValue[0] == '1'
             val rhsSign = rhsValue.stringValue[0] == '1'
 
-            when {
+            val operationOverflow = when {
                 // lhs < 0 && rhs < 0
                 lhsSign && rhsSign -> {
                     // no underflow possible
@@ -1305,7 +1305,7 @@ interface KBvExprSimplifier : KExprSimplifierBase {
                     // overflow if rhs <= (MAX_VALUE / lhs - 1)
                     val maxValue = bvMaxValueSigned(size)
                     val limit = maxValue.signedDivide(lhsValue)
-                    return rhsValue.signedLessOrEqual(limit - one).expr
+                    rhsValue.signedLessOrEqual(limit - one)
                 }
                 // lhs > 0 && rhs > 0
                 !lhsSign && !rhsSign -> {
@@ -1314,7 +1314,7 @@ interface KBvExprSimplifier : KExprSimplifierBase {
                     // overflow if MAX_VALUE / rhs <= lhs - 1
                     val maxValue = bvMaxValueSigned(size)
                     val limit = maxValue.signedDivide(rhsValue)
-                    return limit.signedLessOrEqual(lhsValue - one).expr
+                    limit.signedLessOrEqual(lhsValue - one)
                 }
                 // lhs < 0 && rhs > 0
                 lhsSign && !rhsSign -> {
@@ -1323,7 +1323,7 @@ interface KBvExprSimplifier : KExprSimplifierBase {
                     // underflow if lhs <= MIN_VALUE / rhs - 1
                     val minValue = bvMinValueSigned(size)
                     val limit = minValue.signedDivide(rhsValue)
-                    return lhsValue.signedLessOrEqual(limit - one).expr
+                    lhsValue.signedLessOrEqual(limit - one)
                 }
                 // lhs > 0 && rhs < 0
                 else -> {
@@ -1332,9 +1332,11 @@ interface KBvExprSimplifier : KExprSimplifierBase {
                     // underflow if rhs <= MIN_VALUE / lhs - 1
                     val minValue = bvMinValueSigned(size)
                     val limit = minValue.signedDivide(lhsValue)
-                    return rhsValue.signedLessOrEqual(limit - one).expr
+                    rhsValue.signedLessOrEqual(limit - one)
                 }
             }
+
+            return (!operationOverflow).expr
         }
         return null
     }
@@ -1363,7 +1365,7 @@ interface KBvExprSimplifier : KExprSimplifierBase {
             val longMaxValue = concatBv(zero, bvMaxValueUnsigned(size))
 
             val product = longLhs * longRhs
-            return product.signedLessOrEqual(longMaxValue).expr
+            return product.unsignedLessOrEqual(longMaxValue).expr
         }
 
         return null

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/KFpExprSimplifier.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/KFpExprSimplifier.kt
@@ -50,7 +50,6 @@ import org.ksmt.sort.KRealSort
 import org.ksmt.sort.KSort
 import org.ksmt.utils.BvUtils.bvMaxValueSigned
 import org.ksmt.utils.BvUtils.minus
-import org.ksmt.utils.BvUtils.mkBvFromBigInteger
 import org.ksmt.utils.uncheckedCast
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -502,7 +501,7 @@ interface KFpExprSimplifier : KExprSimplifierBase {
                         }
                         if (decimalValue >= lowLimit && decimalValue <= upperLimit) {
                             val intValue = decimalValue.unscaledValue(rm.value).toBigInteger()
-                            return@simplifyApp mkBvFromBigInteger(intValue, expr.bvSize.toUInt())
+                            return@simplifyApp mkBv(intValue, expr.bvSize.toUInt())
                         }
                     }
                 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/utils/BvUtils.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/utils/BvUtils.kt
@@ -7,6 +7,7 @@ import org.ksmt.expr.KBitVec32Value
 import org.ksmt.expr.KBitVec64Value
 import org.ksmt.expr.KBitVec8Value
 import org.ksmt.expr.KBitVecCustomValue
+import org.ksmt.expr.KBitVecNumberValue
 import org.ksmt.expr.KBitVecValue
 import java.math.BigInteger
 import kotlin.experimental.inv
@@ -294,14 +295,11 @@ object BvUtils {
         return valueMinusOne.bitLength()
     }
 
-    fun KBitVecValue<*>.intValueOrNull(): Int? = when (this) {
-        is KBitVec1Value -> if (value) 1 else 0
-        is KBitVec8Value -> numberValue.toInt()
-        is KBitVec16Value -> numberValue.toInt()
-        is KBitVec32Value -> numberValue
-        is KBitVec64Value -> if (numberValue <= Int.MAX_VALUE) numberValue.toInt() else null
-        is KBitVecCustomValue -> if (value <= Int.MAX_VALUE.toBigInteger()) value.toInt() else null
-        else -> stringValue.toIntOrNull(radix = 2)
+    fun KBitVecValue<*>.bigIntValue(): BigInteger = when (this) {
+        is KBitVec1Value -> if (value) BigInteger.ONE else BigInteger.ZERO
+        is KBitVecNumberValue<*, *> -> numberValue.toBigInteger()
+        is KBitVecCustomValue -> value
+        else -> stringValue.toBigInteger(radix = 2)
     }
 
     fun KBitVecValue<*>.toBigIntegerSigned(): BigInteger =

--- a/ksmt-core/src/main/kotlin/org/ksmt/utils/BvUtils.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/utils/BvUtils.kt
@@ -257,7 +257,7 @@ object BvUtils {
         bv8 = { a, b -> if (b.toInt() !in bv8PossibleShift) 0u else (a.toInt() ushr b.toInt()).toUByte() },
         bv16 = { a, b -> if (b.toInt() !in bv16PossibleShift) 0u else (a.toInt() ushr b.toInt()).toUShort() },
         bv32 = { a, b -> if (b.toInt() !in bv32PossibleShift) 0u else (a.toInt() ushr b.toInt()).toUInt() },
-        bv64 = { a, b -> if (b.toInt() !in bv64PossibleShift) 0u else (a.toLong() ushr b.toInt()).toULong() },
+        bv64 = { a, b -> if (b.toLong() !in bv64PossibleShift) 0u else (a.toLong() ushr b.toInt()).toULong() },
         bvDefault = { a, b ->
             if (b < BigInteger.ZERO || b >= sort.sizeBits.toInt().toBigInteger()) {
                 BigInteger.ZERO

--- a/ksmt-core/src/main/kotlin/org/ksmt/utils/Utils.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/utils/Utils.kt
@@ -35,6 +35,11 @@ fun Number.toUnsignedBigInteger(): BigInteger =
 fun powerOfTwo(power: UInt): BigInteger =
     BigInteger.valueOf(2).pow(power.toInt())
 
+/**
+ * Ensure that BigInteger value is suitable for representation of Bv with [size] bits.
+ * 1. If the value is signed convert it to unsigned with the correct binary representation.
+ * 2. Trim value binary representation up to the [size] bits.
+ * */
 fun BigInteger.normalizeValue(size: UInt): BigInteger =
     this.mod(powerOfTwo(size))
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/utils/Utils.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/utils/Utils.kt
@@ -4,6 +4,7 @@ import org.ksmt.sort.KFp16Sort
 import org.ksmt.sort.KFp32Sort
 import org.ksmt.sort.KFp64Sort
 import org.ksmt.sort.KFpSort
+import java.math.BigInteger
 
 // We can have here `0` as a pad symbol since `toString` can return a string
 // containing fewer symbols than `sizeBits` only for non-negative numbers
@@ -16,6 +17,32 @@ fun Number.toBinary(): String = when (this) {
     is Double -> toRawBits().toBinary()
     else -> error("Unsupported type for transformation into a binary string: ${this::class.simpleName}")
 }
+
+fun Number.toULongValue(): ULong = when (this) {
+    is Byte -> toUByte().toULong()
+    is Short -> toUShort().toULong()
+    is Int -> toUInt().toULong()
+    is Long -> toULong()
+    else -> error("Unsupported type for transformation into a ULong: ${this::class.simpleName}")
+}
+
+fun Number.toBigInteger(): BigInteger =
+    if (this is BigInteger) this else BigInteger.valueOf(toLong())
+
+fun Number.toUnsignedBigInteger(): BigInteger =
+    toULongValue().toLong().toBigInteger()
+
+fun powerOfTwo(power: UInt): BigInteger =
+    BigInteger.valueOf(2).pow(power.toInt())
+
+fun BigInteger.normalizeValue(size: UInt): BigInteger =
+    this.mod(powerOfTwo(size))
+
+fun BigInteger.toBinary(size: UInt): String =
+    toString(2).padStart(size.toInt(), '0')
+
+fun String.toBigInteger(radix: Int): BigInteger =
+    BigInteger(this, radix)
 
 /**
  * Significand for Fp16 takes 10 bits from the float value: from 14 to 23 bits

--- a/ksmt-core/src/test/kotlin/org/ksmt/BvEvalTest.kt
+++ b/ksmt-core/src/test/kotlin/org/ksmt/BvEvalTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.ksmt.expr.KApp
 import org.ksmt.expr.KBitVecValue
 import org.ksmt.expr.KExpr
 import org.ksmt.expr.KInterpretedConstant
@@ -361,6 +362,10 @@ class BvEvalTest {
             val expectedValue = solverValue(expr)
             val actualValue = evalBvExpr(expr)
             assertEquals(expectedValue, actualValue)
+
+            val decl = (expectedValue as KApp<*, *>).decl
+            val declValue = decl.apply(emptyList())
+            assertEquals(expectedValue, declValue)
         }
 
         private fun <T : KSort> solverValue(expr: KExpr<T>): KExpr<T> =

--- a/ksmt-core/src/test/kotlin/org/ksmt/BvEvalTest.kt
+++ b/ksmt-core/src/test/kotlin/org/ksmt/BvEvalTest.kt
@@ -18,6 +18,7 @@ import org.ksmt.utils.BvUtils
 import org.ksmt.utils.uncheckedCast
 import kotlin.random.Random
 import kotlin.random.nextInt
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -247,6 +248,28 @@ class BvEvalTest {
         repeat(5) {
             val extension = random.nextInt(0..100)
             testOperation(sizeBits) { value -> mkBvZeroExtensionExpr(extension, value) }
+        }
+    }
+
+    @Test
+    fun testBvCreateFromNumber() {
+        testBvCreate<Byte>(8u, { random.nextInt().toByte() }, KContext::mkBv, KContext::mkBv)
+        testBvCreate<Short>(16u, { random.nextInt().toShort() }, KContext::mkBv, KContext::mkBv)
+        testBvCreate<Int>(32u, { random.nextInt() }, KContext::mkBv, KContext::mkBv)
+        testBvCreate<Long>(64u, { random.nextLong() }, KContext::mkBv, KContext::mkBv)
+    }
+
+    private inline fun <reified T : Number> testBvCreate(
+        size: UInt,
+        valueGen: () -> T,
+        specializedBuilder: KContext.(T) -> KExpr<*>,
+        genericBuilder: KContext.(T, UInt) -> KExpr<*>
+    ) = KContext().run {
+        repeat(100) {
+            val value = valueGen()
+            val createSpecialized = specializedBuilder(value)
+            val createGeneric = genericBuilder(value, size)
+            assertEquals(createSpecialized, createGeneric)
         }
     }
 

--- a/ksmt-core/src/test/kotlin/org/ksmt/BvEvalTest.kt
+++ b/ksmt-core/src/test/kotlin/org/ksmt/BvEvalTest.kt
@@ -1,0 +1,391 @@
+package org.ksmt
+
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.ksmt.expr.KBitVecValue
+import org.ksmt.expr.KExpr
+import org.ksmt.expr.KInterpretedConstant
+import org.ksmt.expr.rewrite.simplify.KExprSimplifier
+import org.ksmt.solver.KSolver
+import org.ksmt.solver.KSolverStatus
+import org.ksmt.solver.z3.KZ3Solver
+import org.ksmt.sort.KBvSort
+import org.ksmt.sort.KSort
+import org.ksmt.utils.BvUtils
+import org.ksmt.utils.uncheckedCast
+import kotlin.random.Random
+import kotlin.random.nextInt
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Execution(ExecutionMode.CONCURRENT)
+class BvEvalTest {
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvAdd(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvAddExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvAddNoOverflow(sizeBits: Int) {
+        testOperation(sizeBits) { a, b -> mkBvAddNoOverflowExpr(a, b, isSigned = true) }
+        testOperation(sizeBits) { a, b -> mkBvAddNoOverflowExpr(a, b, isSigned = false) }
+    }
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvAddNoUnderflow(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvAddNoUnderflowExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvAnd(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvAndExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvArithShiftRight(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvArithShiftRightExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvConcat(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvConcatExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvDivNoOverflow(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvDivNoOverflowExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvExtract(sizeBits: Int) {
+        repeat(5) {
+            val high = random.nextInt(0 until sizeBits)
+            repeat(5) {
+                val low = random.nextInt(0..high)
+                testOperation(sizeBits) { value -> mkBvExtractExpr(high, low, value) }
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvLogicalShiftRight(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvLogicalShiftRightExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvMul(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvMulExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvMulNoOverflow(sizeBits: Int) {
+        testOperation(sizeBits) { a, b -> mkBvMulNoOverflowExpr(a, b, isSigned = true) }
+        testOperation(sizeBits) { a, b -> mkBvMulNoOverflowExpr(a, b, isSigned = false) }
+    }
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvMulNoUnderflow(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvMulNoUnderflowExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvNAnd(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvNAndExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvNegation(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvNegationExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvNegationNoOverflow(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvNegationNoOverflowExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvNor(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvNorExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvNot(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvNotExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvOr(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvOrExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvReductionAnd(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvReductionAndExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvReductionOr(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvReductionOrExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvRepeat(sizeBits: Int) {
+        repeat(5) {
+            val repetitions = random.nextInt(1..10)
+            testOperation(sizeBits) { value -> mkBvRepeatExpr(repetitions, value) }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvRotateLeft(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvRotateLeftExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvRotateLeftIndexed(sizeBits: Int) {
+        repeat(5) {
+            val rotation = random.nextInt(0..1024)
+            testOperation(sizeBits) { value -> mkBvRotateLeftIndexedExpr(rotation, value) }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvRotateRight(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvRotateRightExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvRotateRightIndexed(sizeBits: Int) {
+        repeat(5) {
+            val rotation = random.nextInt(0..1024)
+            testOperation(sizeBits) { value -> mkBvRotateRightIndexedExpr(rotation, value) }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvShiftLeft(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvShiftLeftExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvSignedDiv(sizeBits: Int) = testOperationNonZeroSecondArg(sizeBits, KContext::mkBvSignedDivExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvSignedGreater(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvSignedGreaterExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvSignedGreaterOrEqual(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvSignedGreaterOrEqualExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvSignedLess(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvSignedLessExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvSignedLessOrEqual(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvSignedLessOrEqualExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvSignedMod(sizeBits: Int) = testOperationNonZeroSecondArg(sizeBits, KContext::mkBvSignedModExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvSignedRem(sizeBits: Int) = testOperationNonZeroSecondArg(sizeBits, KContext::mkBvSignedRemExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvSignExtension(sizeBits: Int) {
+        repeat(5) {
+            val extension = random.nextInt(0..100)
+            testOperation(sizeBits) { value -> mkBvSignExtensionExpr(extension, value) }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvSub(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvSubExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvSubNoOverflow(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvSubNoOverflowExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvSubNoUnderflow(sizeBits: Int) {
+        testOperation(sizeBits) { a, b -> mkBvSubNoUnderflowExpr(a, b, isSigned = true) }
+        testOperation(sizeBits) { a, b -> mkBvSubNoUnderflowExpr(a, b, isSigned = false) }
+    }
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvUnsignedDiv(sizeBits: Int) = testOperationNonZeroSecondArg(sizeBits, KContext::mkBvUnsignedDivExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvUnsignedGreater(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvUnsignedGreaterExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvUnsignedGreaterOrEqual(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvUnsignedGreaterOrEqualExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvUnsignedLess(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvUnsignedLessExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvUnsignedLessOrEqual(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvUnsignedLessOrEqualExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvUnsignedRem(sizeBits: Int) = testOperationNonZeroSecondArg(sizeBits, KContext::mkBvUnsignedRemExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvXNor(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvXNorExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvXor(sizeBits: Int) = testOperation(sizeBits, KContext::mkBvXorExpr)
+
+    @ParameterizedTest
+    @MethodSource("bvSizes")
+    fun testBvZeroExtension(sizeBits: Int) {
+        repeat(5) {
+            val extension = random.nextInt(0..100)
+            testOperation(sizeBits) { value -> mkBvZeroExtensionExpr(extension, value) }
+        }
+    }
+
+    private fun <S : KBvSort> KContext.randomBvValues(sort: S) = sequence<KBitVecValue<S>> {
+        // special values
+        with(BvUtils) {
+            yield(bvMaxValueSigned(sort.sizeBits).uncheckedCast())
+            yield(bvMaxValueUnsigned(sort.sizeBits).uncheckedCast())
+            yield(bvMinValueSigned(sort.sizeBits).uncheckedCast())
+            yield(bvZero(sort.sizeBits).uncheckedCast())
+            yield(bvOne(sort.sizeBits).uncheckedCast())
+        }
+
+        // small positive values
+        repeat(5) {
+            val value = random.nextInt(1..20)
+            yield(mkBv(value, sort))
+        }
+
+        // small negative values
+        repeat(5) {
+            val value = random.nextInt(1..20)
+            yield(mkBv(-value, sort))
+        }
+
+        // random values
+        repeat(30) {
+            val binaryValue = String(CharArray(sort.sizeBits.toInt()) {
+                if (random.nextBoolean()) '1' else '0'
+            })
+            yield(mkBv(binaryValue, sort.sizeBits).uncheckedCast())
+        }
+    }
+
+    private fun <S : KBvSort> KContext.nonZeroRandomValues(sort: S): Sequence<KBitVecValue<S>> {
+        val zero = mkBv(0, sort)
+        return randomBvValues(sort).filter { it != zero }
+    }
+
+    private fun <S : KBvSort, T : KSort> testOperation(
+        size: Int,
+        operation: KContext.(KExpr<S>) -> KExpr<T>
+    ) = runTest(size) { sort: S, checker ->
+        randomBvValues(sort).forEach { value ->
+            val expr = operation(value)
+            checker.check(expr)
+        }
+    }
+
+    private fun <S : KBvSort, T : KSort> testOperation(
+        size: Int,
+        operation: KContext.(KExpr<S>, KExpr<S>) -> KExpr<T>
+    ) = runTest(size) { sort: S, checker ->
+        randomBvValues(sort).forEach { a ->
+            randomBvValues(sort).forEach { b ->
+                val expr = operation(a, b)
+                checker.check(expr)
+            }
+        }
+    }
+
+    private fun <S : KBvSort, T : KSort> testOperationNonZeroSecondArg(
+        size: Int,
+        operation: KContext.(KExpr<S>, KExpr<S>) -> KExpr<T>
+    ) = runTest(size) { sort: S, checker ->
+        randomBvValues(sort).forEach { a ->
+            nonZeroRandomValues(sort).forEach { b ->
+                val expr = operation(a, b)
+                checker.check(expr)
+            }
+        }
+    }
+
+    private fun <S : KBvSort> runTest(size: Int, test: KContext.(S, TestRunner) -> Unit) {
+        val ctx = KContext()
+        val sort: S = ctx.mkBvSort(size.toUInt()).uncheckedCast()
+        KZ3Solver(ctx).use { solver ->
+            val checker = TestRunner(ctx, solver)
+            ctx.test(sort, checker)
+        }
+    }
+
+    private class TestRunner(
+        private val ctx: KContext,
+        private val solver: KSolver<*>
+    ) {
+
+        fun <T : KSort> check(expr: KExpr<T>) {
+            val expectedValue = solverValue(expr)
+            val actualValue = evalBvExpr(expr)
+            assertEquals(expectedValue, actualValue)
+        }
+
+        private fun <T : KSort> solverValue(expr: KExpr<T>): KExpr<T> =
+            withSolverScope { solver ->
+                with(ctx) {
+                    val valueVar = mkFreshConst("v", expr.sort)
+                    solver.assert(valueVar eq expr)
+                    assertEquals(KSolverStatus.SAT, solver.check())
+                    val value = solver.model().eval(valueVar)
+                    assertTrue(value is KInterpretedConstant)
+                    value
+                }
+            }
+
+
+        private fun <T : KSort> evalBvExpr(expr: KExpr<T>): KExpr<T> {
+            val evaluator = KExprSimplifier(ctx)
+            return evaluator.apply(expr)
+        }
+
+        private fun <T> withSolverScope(block: (KSolver<*>) -> T): T = try {
+            solver.push()
+            block(solver)
+        } finally {
+            solver.pop()
+        }
+    }
+
+    companion object {
+        private val random = Random(42)
+
+        private val bvSizesToTest by lazy {
+            val context = KContext()
+            val smallCustomBv = context.mkBvSort(17u)
+            val largeCustomBv = context.mkBvSort(111u)
+
+            listOf(
+                context.bv1Sort,
+                context.bv8Sort,
+                context.bv16Sort,
+                context.bv32Sort,
+                context.bv64Sort,
+                smallCustomBv,
+                largeCustomBv
+            ).map { it.sizeBits.toInt() }
+        }
+
+        @JvmStatic
+        fun bvSizes() = bvSizesToTest.map { Arguments.of(it) }
+    }
+}

--- a/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstDeserializer.kt
+++ b/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstDeserializer.kt
@@ -110,7 +110,7 @@ class AstDeserializer(
             ExprKind.BitVec16Value -> mkBv(readShort())
             ExprKind.BitVec32Value -> mkBv(readInt())
             ExprKind.BitVec64Value -> mkBv(readLong())
-            ExprKind.BitVecCustomValue -> mkBv(readString(), readUInt())
+            ExprKind.BitVecCustomValue -> mkBv(readBigInteger(), readUInt())
             ExprKind.BvNotExpr -> deserialize(::mkBvNotExpr)
             ExprKind.BvReductionAndExpr -> deserialize(::mkBvReductionAndExpr)
             ExprKind.BvReductionOrExpr -> deserialize(::mkBvReductionOrExpr)

--- a/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstSerializer.kt
+++ b/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstSerializer.kt
@@ -393,7 +393,7 @@ class AstSerializer(
     override fun transform(expr: KBitVecCustomValue) = with(expr) {
         transform {
             writeExpr {
-                writeString(binaryStringValue)
+                writeString(stringValue)
                 writeUInt(sort.sizeBits)
             }
         }

--- a/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstSerializer.kt
+++ b/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstSerializer.kt
@@ -393,7 +393,7 @@ class AstSerializer(
     override fun transform(expr: KBitVecCustomValue) = with(expr) {
         transform {
             writeExpr {
-                writeString(stringValue)
+                writeBigInteger(value)
                 writeUInt(sort.sizeBits)
             }
         }

--- a/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/SerializerUtils.kt
+++ b/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/SerializerUtils.kt
@@ -1,0 +1,14 @@
+package org.ksmt.runner.serializer
+
+import com.jetbrains.rd.framework.AbstractBuffer
+import java.math.BigInteger
+
+fun AbstractBuffer.writeBigInteger(value: BigInteger) {
+    val bytes = value.toByteArray()
+    writeByteArray(bytes)
+}
+
+fun AbstractBuffer.readBigInteger(): BigInteger {
+    val bytes = readByteArray()
+    return BigInteger(bytes)
+}

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
@@ -241,7 +241,7 @@ open class KZ3ExprInternalizer(
             }
 
             is KBitVecCustomValue -> {
-                val bits = expr.binaryStringValue.reversed().let { value ->
+                val bits = expr.stringValue.reversed().let { value ->
                     BooleanArray(value.length) { value[it] == '1' }
                 }
                 Native.mkBvNumeral(nCtx, bits.size, bits)

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
@@ -241,9 +241,7 @@ open class KZ3ExprInternalizer(
             }
 
             is KBitVecCustomValue -> {
-                val bits = expr.stringValue.reversed().let { value ->
-                    BooleanArray(value.length) { value[it] == '1' }
-                }
+                val bits = BooleanArray(expr.sizeBits.toInt()) { expr.value.testBit(it) }
                 Native.mkBvNumeral(nCtx, bits.size, bits)
             }
 

--- a/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/BitVecTest.kt
+++ b/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/BitVecTest.kt
@@ -165,8 +165,8 @@ class BitVecTest {
         val positiveBvFromString = mkBv(positiveValue, sizeBits) as KBitVecCustomValue
         val negativeBvFromString = mkBv(negativeValue, sizeBits) as KBitVecCustomValue
 
-        assertEquals(positiveBvFromString.binaryStringValue, positiveValue)
-        assertEquals(negativeBvFromString.binaryStringValue, negativeValue)
+        assertEquals(positiveBvFromString.stringValue, positiveValue)
+        assertEquals(negativeBvFromString.stringValue, negativeValue)
 
         assertEquals(positiveBvFromString.sort.sizeBits, sizeBits)
         assertEquals(negativeBvFromString.sort.sizeBits, sizeBits)
@@ -182,7 +182,7 @@ class BitVecTest {
         val sizeBits = 42u
         val bitvector = mkBv(Long.MAX_VALUE, sizeBits) as KBitVecCustomValue
 
-        assertEquals(bitvector.binaryStringValue, Long.MAX_VALUE.toBinary().takeLast(sizeBits.toInt()))
+        assertEquals(bitvector.stringValue, Long.MAX_VALUE.toBinary().takeLast(sizeBits.toInt()))
     }
 
     @Test
@@ -193,11 +193,11 @@ class BitVecTest {
 
         val sizeDifference = sizeBits.toInt() - Long.SIZE_BITS
 
-        assertEquals(positiveBv.binaryStringValue.take(sizeDifference), "0".repeat(sizeDifference))
-        assertEquals(negativeBv.binaryStringValue.take(sizeDifference), "1".repeat(sizeDifference))
+        assertEquals(positiveBv.stringValue.take(sizeDifference), "0".repeat(sizeDifference))
+        assertEquals(negativeBv.stringValue.take(sizeDifference), "1".repeat(sizeDifference))
 
-        assertEquals(positiveBv.binaryStringValue.takeLast(Long.SIZE_BITS), Long.MAX_VALUE.toBinary())
-        assertEquals(negativeBv.binaryStringValue.takeLast(Long.SIZE_BITS), Long.MIN_VALUE.toBinary())
+        assertEquals(positiveBv.stringValue.takeLast(Long.SIZE_BITS), Long.MAX_VALUE.toBinary())
+        assertEquals(negativeBv.stringValue.takeLast(Long.SIZE_BITS), Long.MIN_VALUE.toBinary())
     }
 
     @Test
@@ -532,7 +532,7 @@ class BitVecTest {
         val resultValue = solver.model().eval(symbolicConst) as KBitVecCustomValue
         val expectedResult = firstBv.numberValue.toBinary() + secondBv.numberValue.toBinary()
 
-        assertEquals(expectedResult, resultValue.binaryStringValue)
+        assertEquals(expectedResult, resultValue.stringValue)
     }
 
     @Test

--- a/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/FloatingPointTest.kt
+++ b/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/FloatingPointTest.kt
@@ -1,5 +1,9 @@
 package org.ksmt.solver.z3
 
+import com.microsoft.z3.Context
+import com.microsoft.z3.Expr
+import com.microsoft.z3.FPSort
+import com.microsoft.z3.Status
 import java.lang.Float.intBitsToFloat
 import kotlin.math.abs
 import kotlin.math.max
@@ -582,6 +586,21 @@ class FloatingPointTest {
         concreteOperation = { -0.0f }
     )
 
+    @Test
+    fun testMatchSolverInternalNan() = compareWithSolverInternal(::compareNaNWithSolverInternal)
+
+    @Test
+    fun testMatchSolverInternalPosInf() = compareWithSolverInternal(::comparePosInfWithSolverInternal)
+
+    @Test
+    fun testMatchSolverInternalNegInf() = compareWithSolverInternal(::compareNegInfWithSolverInternal)
+
+    @Test
+    fun testMatchSolverInternalPosZero() = compareWithSolverInternal(::comparePosZeroWithSolverInternal)
+
+    @Test
+    fun testMatchSolverInternalNegZero() = compareWithSolverInternal(::compareNegZeroWithSolverInternal)
+
     private fun testCompare(
         symbolicOperation: (KExpr<KFp64Sort>, KExpr<KFp64Sort>) -> KExpr<KBoolSort>,
         concreteOperation: (Double, Double) -> Boolean
@@ -624,6 +643,73 @@ class FloatingPointTest {
                 assertEquals(concreteOperation(fp.value), eval(variable) is KTrue)
             }
         }
+    }
+
+    private fun compareWithSolverInternal(check: (KFpSort) -> Unit) {
+        val sorts = with(context) {
+            val fpCustom = mkFpSort(5u, 10u)
+            listOf(fp16Sort, fp32Sort, fp64Sort, mkFp128Sort(), fpCustom)
+        }
+        sorts.forEach(check)
+    }
+
+    private fun <S : KFpSort> compareNaNWithSolverInternal(sort: S) = compareWithSolverInternal(
+        sort = sort,
+        operation = context::mkFpNan,
+        solverInternal = { mkFPNaN(it) }
+    )
+
+    private fun <S : KFpSort> comparePosInfWithSolverInternal(sort: S) = compareWithSolverInternal(
+        sort = sort,
+        operation = { context.mkFpInf(sort = sort, signBit = false) },
+        solverInternal = { mkFPInf(it, false) }
+    )
+
+    private fun <S : KFpSort> compareNegInfWithSolverInternal(sort: S) = compareWithSolverInternal(
+        sort = sort,
+        operation = { context.mkFpInf(sort = sort, signBit = true) },
+        solverInternal = { mkFPInf(it, true) }
+    )
+
+    private fun <S : KFpSort> comparePosZeroWithSolverInternal(sort: S) = compareWithSolverInternal(
+        sort = sort,
+        operation = { context.mkFpZero(sort = sort, signBit = false) },
+        solverInternal = { mkFPZero(it, false) }
+    )
+
+    private fun <S : KFpSort> compareNegZeroWithSolverInternal(sort: S) = compareWithSolverInternal(
+        sort = sort,
+        operation = { context.mkFpZero(sort = sort, signBit = true) },
+        solverInternal = { mkFPZero(it, true) }
+    )
+
+    private fun <S : KFpSort> compareWithSolverInternal(
+        sort: S,
+        operation: (S) -> KExpr<S>,
+        solverInternal: Context.(FPSort) -> Expr<*>
+    ) = KZ3Context().use { solverInternalCtx ->
+        val internalizer = KZ3ExprInternalizer(context, solverInternalCtx)
+
+        val solverInternalSort = with(internalizer) { sort.internalizeSortWrapped() as FPSort }
+        val solverInternalExpr = solverInternal(solverInternalCtx.nativeContext, solverInternalSort)
+
+        val ksmtExpr = operation(sort)
+        val ksmtInternalizedExpr = with(internalizer) { ksmtExpr.internalizeExprWrapped() }
+
+        val check = solverInternalCtx.nativeContext.mkEq(solverInternalExpr, ksmtInternalizedExpr)
+
+        val checker = solverInternalCtx.nativeContext.mkSolver()
+        checker.add(check)
+        val status = checker.check()
+
+        val message = """
+            Representation mismatch for $sort
+            Expected: $solverInternalExpr
+            Actual: $ksmtInternalizedExpr
+            Actual KSMT: $ksmtExpr
+        """.trimIndent()
+
+        assertEquals(Status.SATISFIABLE, status, message)
     }
 
     @Test


### PR DESCRIPTION
Use BigInteger for custom sized Bv representation. 
This representation allows us to speed up various KSMT operations and results in a 2x performance gain on expression creation benchmark. 