### PR TITLE
Bitwuzla array lambdas

### DIFF
--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprInternalizer.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprInternalizer.kt
@@ -729,7 +729,7 @@ open class KBitwuzlaExprInternalizer(
         return mkLambdaTerm(boundVar, lambdaBody)
     }
 
-    private fun mkLambdaTerm(boundVar: BitwuzlaSort, body: BitwuzlaTerm): BitwuzlaTerm =
+    private fun mkLambdaTerm(boundVar: BitwuzlaTerm, body: BitwuzlaTerm): BitwuzlaTerm =
         Native.bitwuzlaMkTerm2(bitwuzlaCtx.bitwuzla, BitwuzlaKind.BITWUZLA_KIND_LAMBDA, boundVar, body)
 
     override fun transform(


### PR DESCRIPTION
Better support for array lambda expressions in bitwuzla. Produce quantifiers for array eq/distinct expressions only. 