### PR TITLE
Add support for macOS with aarch64

### DIFF
--- a/ksmt-core/src/main/kotlin/org/ksmt/utils/NativeLibraryLoader.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/utils/NativeLibraryLoader.kt
@@ -8,7 +8,7 @@ object NativeLibraryLoader {
         LINUX, WINDOWS, MACOS
     }
 
-    private val supportedArchs = setOf("amd64", "x86_64")
+    private val supportedArchs = setOf("amd64", "x86_64", "aarch64")
 
     fun load(libraries: (OS) -> List<String>) {
         val arch = System.getProperty("os.arch")

--- a/ksmt-z3/build.gradle.kts
+++ b/ksmt-z3/build.gradle.kts
@@ -9,14 +9,15 @@ repositories {
     mavenCentral()
 }
 
-val z3Version = "4.11.2"
+val z3Version = "4.12.1"
 
 val z3JavaJar by lazy { mkZ3ReleaseDownloadTask("x64-win", "*.jar") }
 
 val z3Binaries = listOf(
     mkZ3ReleaseDownloadTask("x64-win", "*.dll"),
-    mkZ3ReleaseDownloadTask("x64-glibc-2.31", "*.so"),
-    mkZ3ReleaseDownloadTask("x64-osx-10.16", "*.dylib")
+    mkZ3ReleaseDownloadTask("x64-glibc-2.35", "*.so"),
+    mkZ3ReleaseDownloadTask("x64-osx-10.16", "*.dylib"),
+    mkZ3ReleaseDownloadTask("arm64-osx-11.0", "*.dylib")
 )
 
 dependencies {
@@ -27,6 +28,8 @@ dependencies {
 }
 
 tasks.withType<ProcessResources> {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+
     dependsOn.addAll(z3Binaries)
     z3Binaries.forEach { z3BinaryTask ->
         from(z3BinaryTask.outputFiles) {


### PR DESCRIPTION
Download required Z3 libraries from the releases for computers with macOS on Apple Silicon processors.

Updated Z3 version from `4.11.2` to `4.12.1`

![Screenshot 2023-02-23 at 14 56 44](https://user-images.githubusercontent.com/31047452/220899077-a634e319-4b3f-44f8-b56e-900a6a33ceb2.png)
