### PR TITLE
Bitwuzla ctx improvement

### DIFF
--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaContext.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaContext.kt
@@ -354,7 +354,7 @@ open class KBitwuzlaContext(val ctx: KContext) : AutoCloseable {
         private fun <T : KSort> KExpr<T>.transformQuantifier(bounds: List<KDecl<*>>, body: KExpr<*>): KExpr<T> {
             if (quantifiedVarsScope.lastOrNull()?.first != this) {
                 quantifiedVarsScope.add(this to currentlyIgnoredDeclarations)
-                val ignoredDecls = currentlyIgnoredDeclarations?.toMutableSet() ?: hashSetOf()
+                val ignoredDecls = currentlyIgnoredDeclarations?.toHashSet() ?: hashSetOf()
                 ignoredDecls.addAll(bounds)
                 currentlyIgnoredDeclarations = ignoredDecls
             }

--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaContext.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaContext.kt
@@ -79,10 +79,10 @@ open class KBitwuzlaContext(val ctx: KContext) : AutoCloseable {
      * See [ExprMover].
      * */
     fun findExprTerm(expr: KExpr<*>): BitwuzlaTerm? {
+        val globalTerm = exprGlobalCache[expr] ?: return null
+
         val currentLevelTerm = exprCurrentLevelCache[expr]
         if (currentLevelTerm != null) return currentLevelTerm
-
-        val globalTerm = exprGlobalCache[expr] ?: return null
 
         currentLevelExprMover.apply(expr)
 

--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprInternalizer.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprInternalizer.kt
@@ -181,7 +181,7 @@ open class KBitwuzlaExprInternalizer(
     }
 
     override fun findInternalizedExpr(expr: KExpr<*>): BitwuzlaTerm? {
-        return bitwuzlaCtx[expr]
+        return bitwuzlaCtx.findExprTerm(expr)
     }
 
     override fun saveInternalizedExpr(expr: KExpr<*>, internalized: BitwuzlaTerm) {
@@ -252,7 +252,7 @@ open class KBitwuzlaExprInternalizer(
     fun <T : KSort> KDecl<T>.bitwuzlaFunctionSort(): BitwuzlaSort = accept(functionSortInternalizer)
 
     private fun saveExprInternalizationResult(expr: KExpr<*>, term: BitwuzlaTerm) {
-        bitwuzlaCtx.internalizeExpr(expr) { term }
+        bitwuzlaCtx.saveExprTerm(expr, term)
 
         // Save only constants
         if (expr !is KInterpretedValue<*>) return

--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaModel.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaModel.kt
@@ -67,6 +67,8 @@ open class KBitwuzlaModel(
         ctx.ensureContextMatch(decl)
         bitwuzlaCtx.ensureActive()
 
+        if (decl !in modelDeclarations) return null
+
         val interpretation = interpretations.getOrPut(decl) {
             // Constant was not internalized --> constant is unknown to solver --> constant is not present in model
             val bitwuzlaConstant = bitwuzlaCtx.findConstant(decl)

--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaSolver.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaSolver.kt
@@ -14,7 +14,7 @@ import org.ksmt.sort.KBoolSort
 import kotlin.time.Duration
 
 open class KBitwuzlaSolver(private val ctx: KContext) : KSolver<KBitwuzlaSolverConfiguration> {
-    open val bitwuzlaCtx = KBitwuzlaContext()
+    open val bitwuzlaCtx = KBitwuzlaContext(ctx)
     open val exprInternalizer: KBitwuzlaExprInternalizer by lazy {
         KBitwuzlaExprInternalizer(bitwuzlaCtx)
     }

--- a/ksmt-bitwuzla/src/test/kotlin/org/ksmt/solver/bitwuzla/ConverterTest.kt
+++ b/ksmt-bitwuzla/src/test/kotlin/org/ksmt/solver/bitwuzla/ConverterTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertTrue
 
 class ConverterTest {
     private val ctx = KContext()
-    private val bitwuzlaCtx = KBitwuzlaContext()
+    private val bitwuzlaCtx = KBitwuzlaContext(ctx)
     private val internalizer = KBitwuzlaExprInternalizer(bitwuzlaCtx)
     private val converter = KBitwuzlaExprConverter(ctx, bitwuzlaCtx)
     private val sortChecker = SortChecker(ctx)

--- a/ksmt-test/src/main/kotlin/org/ksmt/test/TestWorkerProcess.kt
+++ b/ksmt-test/src/main/kotlin/org/ksmt/test/TestWorkerProcess.kt
@@ -85,7 +85,7 @@ class TestWorkerProcess : ChildProcessBase<TestProtocolModel>() {
     }
 
     private fun internalizeAndConvertBitwuzla(assertions: List<KExpr<KBoolSort>>): List<KExpr<KBoolSort>> =
-        KBitwuzlaContext().use { bitwuzlaCtx ->
+        KBitwuzlaContext(ctx).use { bitwuzlaCtx ->
             val internalizer = KBitwuzlaExprInternalizer(bitwuzlaCtx)
             val bitwuzlaAssertions = with(internalizer) {
                 assertions.map { it.internalize() }


### PR DESCRIPTION
Avoid full expression cache copying on each push. Store at most 2 x number of internalized expressions.
