### PR TITLE
Internalizer optimization

### DIFF
--- a/buildSrc/src/main/kotlin/org.ksmt.ksmt-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/org.ksmt.ksmt-base.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
     // Primitive collections
-    implementation("it.unimi.dsi:fastutil-core:8.5.11")
+    implementation("it.unimi.dsi:fastutil-core:8.5.11") // 6.1MB
 
     testImplementation(kotlin("test"))
 }

--- a/buildSrc/src/main/kotlin/org.ksmt.ksmt-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/org.ksmt.ksmt-base.gradle.kts
@@ -16,6 +16,9 @@ repositories {
 }
 
 dependencies {
+    // Primitive collections
+    implementation("it.unimi.dsi:fastutil-core:8.5.11")
+
     testImplementation(kotlin("test"))
 }
 

--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprConverter.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprConverter.kt
@@ -20,7 +20,7 @@ import org.ksmt.solver.bitwuzla.bindings.BitwuzlaKind
 import org.ksmt.solver.bitwuzla.bindings.BitwuzlaSort
 import org.ksmt.solver.bitwuzla.bindings.BitwuzlaTerm
 import org.ksmt.solver.bitwuzla.bindings.Native
-import org.ksmt.solver.util.KExprConverterBase.Companion.ExprConversionResult
+import org.ksmt.solver.util.ExprConversionResult
 import org.ksmt.solver.util.KExprLongConverterBase
 import org.ksmt.sort.KArraySort
 import org.ksmt.sort.KBoolSort

--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprConverter.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprConverter.kt
@@ -10,15 +10,18 @@ import org.ksmt.expr.KBitVec32Value
 import org.ksmt.expr.KBitVecValue
 import org.ksmt.expr.KExpr
 import org.ksmt.expr.KFpRoundingMode
+import org.ksmt.expr.KInterpretedValue
 import org.ksmt.expr.printer.ExpressionPrinter
 import org.ksmt.expr.transformer.KNonRecursiveTransformer
 import org.ksmt.expr.transformer.KTransformerBase
 import org.ksmt.solver.KSolverUnsupportedFeatureException
+import org.ksmt.solver.bitwuzla.bindings.Bitwuzla
 import org.ksmt.solver.bitwuzla.bindings.BitwuzlaKind
 import org.ksmt.solver.bitwuzla.bindings.BitwuzlaSort
 import org.ksmt.solver.bitwuzla.bindings.BitwuzlaTerm
 import org.ksmt.solver.bitwuzla.bindings.Native
-import org.ksmt.solver.util.KExprConverterBase
+import org.ksmt.solver.util.KExprConverterBase.Companion.ExprConversionResult
+import org.ksmt.solver.util.KExprLongConverterBase
 import org.ksmt.sort.KArraySort
 import org.ksmt.sort.KBoolSort
 import org.ksmt.sort.KBv1Sort
@@ -37,7 +40,8 @@ open class KBitwuzlaExprConverter(
     private val ctx: KContext,
     private val bitwuzlaCtx: KBitwuzlaContext,
     private val scopedVars: Map<BitwuzlaTerm, KDecl<*>>? = null
-) : KExprConverterBase<BitwuzlaTerm>() {
+) : KExprLongConverterBase() {
+    private val bitwuzla: Bitwuzla = bitwuzlaCtx.bitwuzla
 
     private val adapterTermRewriter = AdapterTermRewriter(ctx)
 
@@ -50,7 +54,7 @@ open class KBitwuzlaExprConverter(
      * @see convertToBoolIfNeeded
      * */
     fun <T : KSort> BitwuzlaTerm.convertExpr(expectedSort: T): KExpr<T> =
-        convertFromNative<KSort>()
+        convertFromNative<KSort>(this)
             .convertToExpectedIfNeeded(expectedSort)
             .let { adapterTermRewriter.apply(it) }
 
@@ -254,7 +258,7 @@ open class KBitwuzlaExprConverter(
         check(children.isNotEmpty()) { "Apply has no function term" }
 
         val function = children[0]
-        val appArgs = children.drop(1).toTypedArray()
+        val appArgs = children.copyOfRange(fromIndex = 1, toIndex = children.size)
 
         return expr.convertList(appArgs) { convertedArgs: List<KExpr<KSort>> ->
             check(Native.bitwuzlaTermIsFun(function)) { "Expected a function term, actual: $function" }
@@ -337,17 +341,17 @@ open class KBitwuzlaExprConverter(
             // convert Bv value from native representation
             when {
                 size <= Int.SIZE_BITS -> {
-                    val bits = Native.bitwuzlaBvConstNodeGetBitsUInt32(bitwuzlaCtx.bitwuzla, expr)
+                    val bits = Native.bitwuzlaBvConstNodeGetBitsUInt32(bitwuzla, expr)
                     mkBv(bits, size.toUInt())
                 }
                 else -> {
-                    val intBits = Native.bitwuzlaBvConstNodeGetBitsUIntArray(bitwuzlaCtx.bitwuzla, expr)
+                    val intBits = Native.bitwuzlaBvConstNodeGetBitsUIntArray(bitwuzla, expr)
                     val bits = bvBitsToBigInteger(intBits)
                     mkBv(bits, size.toUInt())
                 }
             }
         } else {
-            val value = Native.bitwuzlaGetBvValue(bitwuzlaCtx.bitwuzla, expr)
+            val value = Native.bitwuzlaGetBvValue(bitwuzla, expr)
             mkBv(value, size.toUInt())
         }
 
@@ -362,18 +366,18 @@ open class KBitwuzlaExprConverter(
         val convertedValue = if (Native.bitwuzlaTermIsFpValue(expr)) {
             when (sort) {
                 fp32Sort -> {
-                    val fpBits = Native.bitwuzlaFpConstNodeGetBitsUInt32(bitwuzlaCtx.bitwuzla, expr)
+                    val fpBits = Native.bitwuzlaFpConstNodeGetBitsUInt32(bitwuzla, expr)
                     mkFp(Float.fromBits(fpBits), sort)
                 }
                 fp64Sort -> {
-                    val fpBitsArray = Native.bitwuzlaFpConstNodeGetBitsUIntArray(bitwuzlaCtx.bitwuzla, expr)
+                    val fpBitsArray = Native.bitwuzlaFpConstNodeGetBitsUIntArray(bitwuzla, expr)
                     val higherBits = fpBitsArray[1].toLong() shl Int.SIZE_BITS
                     val lowerBits = fpBitsArray[0].toUInt().toLong()
                     val fpBits = higherBits or lowerBits
                     mkFp(Double.fromBits(fpBits), sort)
                 }
                 else -> {
-                    val fpBitsArray = Native.bitwuzlaFpConstNodeGetBitsUIntArray(bitwuzlaCtx.bitwuzla, expr)
+                    val fpBitsArray = Native.bitwuzlaFpConstNodeGetBitsUIntArray(bitwuzla, expr)
                     val fpBits = bvBitsToBigInteger(fpBitsArray)
 
                     val significandMask = powerOfTwo(sort.significandBits - 1u) - BigInteger.ONE
@@ -392,7 +396,7 @@ open class KBitwuzlaExprConverter(
                 }
             }
         } else {
-            val value = Native.bitwuzlaGetFpValue(bitwuzlaCtx.bitwuzla, expr)
+            val value = Native.bitwuzlaGetFpValue(bitwuzla, expr)
 
             mkFpFromBvExpr(
                 sign = mkBv(value.sign, sizeBits = 1u).uncheckedCast(),
@@ -928,6 +932,10 @@ open class KBitwuzlaExprConverter(
      * Remove auxiliary terms introduced by [convertToBoolIfNeeded] and [convertToExpectedIfNeeded].
      * */
     private inner class AdapterTermRewriter(ctx: KContext) : KNonRecursiveTransformer(ctx) {
+        // We can skip values transformation since values may not contain any adapter terms
+        override fun <T : KSort> exprTransformationRequired(expr: KExpr<T>): Boolean =
+            expr !is KInterpretedValue<T>
+
         /**
          * x: Bool
          * (toBv x) -> (ite x #b1 #b0)
@@ -1078,6 +1086,6 @@ open class KBitwuzlaExprConverter(
         op: (List<KExpr<A>>) -> KExpr<T>
     ): ExprConversionResult = convertList(getTermChildren(this), op)
 
-    fun getTermChildren(term: BitwuzlaTerm): Array<BitwuzlaTerm> =
-        Native.bitwuzlaTermGetChildren(term).toTypedArray()
+    fun getTermChildren(term: BitwuzlaTerm): LongArray =
+        Native.bitwuzlaTermGetChildren(term)
 }

--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprConverter.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaExprConverter.kt
@@ -82,7 +82,7 @@ open class KBitwuzlaExprConverter(
         bitwuzlaCtx.findConvertedExpr(expr)
 
     override fun saveConvertedNative(native: BitwuzlaTerm, converted: KExpr<*>) {
-        bitwuzlaCtx.convertExpr(native) { converted }
+        bitwuzlaCtx.saveConvertedExpr(native, converted)
     }
 
     private fun BitwuzlaSort.convertSort(): KSort = bitwuzlaCtx.convertSort(this) {

--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaModel.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaModel.kt
@@ -28,7 +28,7 @@ open class KBitwuzlaModel(
     private val modelDeclarations = assertedDeclarations.toHashSet()
 
     override val declarations: Set<KDecl<*>>
-        get() = modelDeclarations.toSet()
+        get() = modelDeclarations.toHashSet()
 
     override fun <T : KSort> eval(expr: KExpr<T>, isComplete: Boolean): KExpr<T> {
         ctx.ensureContextMatch(expr)

--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/bindings/Native.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/bindings/Native.kt
@@ -99,6 +99,7 @@ object Native {
      *
      * @see BitwuzlaOption
      */
+    @JvmStatic
     fun bitwuzlaSetOption(bitwuzla: Bitwuzla, option: BitwuzlaOption, value: Int) =
         bitwuzlaSetOption(bitwuzla, option.value, value)
 
@@ -114,6 +115,7 @@ object Native {
      *
      * @see BitwuzlaOption
      */
+    @JvmStatic
     fun bitwuzlaSetOptionStr(bitwuzla: Bitwuzla, option: BitwuzlaOption, value: String) =
         bitwuzlaSetOptionStr(bitwuzla, option.value, value)
 
@@ -130,6 +132,7 @@ object Native {
      *
      * @see BitwuzlaOption
      */
+    @JvmStatic
     fun bitwuzlaGetOption(bitwuzla: Bitwuzla, option: BitwuzlaOption): Int =
         bitwuzlaGetOption(bitwuzla, option.value)
 
@@ -148,6 +151,7 @@ object Native {
      * @see BitwuzlaOption
      * @see bitwuzlaSetOptionStr
      */
+    @JvmStatic
     fun bitwuzlaGetOptionStr(bitwuzla: Bitwuzla, option: BitwuzlaOption): String =
         bitwuzlaGetOptionStr(bitwuzla, option.value)
 
@@ -448,6 +452,7 @@ object Native {
      * @see bitwuzlaMkBvSort
      * @see BitwuzlaBVBase
      */
+    @JvmStatic
     fun bitwuzlaMkBvValue(
         bitwuzla: Bitwuzla,
         sort: BitwuzlaSort,
@@ -513,6 +518,7 @@ object Native {
      *
      * @see BitwuzlaRoundingMode
      */
+    @JvmStatic
     fun bitwuzlaMkRmValue(bitwuzla: Bitwuzla, rm: BitwuzlaRoundingMode): BitwuzlaTerm  =
         bitwuzlaMkRmValue(bitwuzla, rm.value)
 
@@ -530,6 +536,7 @@ object Native {
      *
      * @see  BitwuzlaKind
      */
+    @JvmStatic
     fun bitwuzlaMkTerm1(bitwuzla: Bitwuzla, kind: BitwuzlaKind, arg: BitwuzlaTerm): BitwuzlaTerm =
         bitwuzlaMkTerm1(bitwuzla, kind.value, arg)
 
@@ -548,6 +555,7 @@ object Native {
      *
      * @see  BitwuzlaKind
      */
+    @JvmStatic
     fun bitwuzlaMkTerm2(
         bitwuzla: Bitwuzla,
         kind: BitwuzlaKind,
@@ -576,6 +584,7 @@ object Native {
      *
      * @see  BitwuzlaKind
      */
+    @JvmStatic
     fun bitwuzlaMkTerm3(
         bitwuzla: Bitwuzla,
         kind: BitwuzlaKind,
@@ -604,6 +613,7 @@ object Native {
      *
      * @see  BitwuzlaKind
      */
+    @JvmStatic
     fun bitwuzlaMkTerm(bitwuzla: Bitwuzla, kind: BitwuzlaKind, args: LongArray): BitwuzlaTerm =
         bitwuzlaMkTerm(bitwuzla, kind.value, args)
 
@@ -622,6 +632,7 @@ object Native {
      *
      * @see  BitwuzlaKind
      */
+    @JvmStatic
     fun bitwuzlaMkTerm1Indexed1(
         bitwuzla: Bitwuzla,
         kind: BitwuzlaKind,
@@ -651,6 +662,7 @@ object Native {
      *
      * @see  BitwuzlaKind
      */
+    @JvmStatic
     fun bitwuzlaMkTerm1Indexed2(
         bitwuzla: Bitwuzla,
         kind: BitwuzlaKind,
@@ -682,6 +694,7 @@ object Native {
      *
      * @see  BitwuzlaKind
      */
+    @JvmStatic
     fun bitwuzlaMkTerm2Indexed1(
         bitwuzla: Bitwuzla,
         kind: BitwuzlaKind,
@@ -953,6 +966,7 @@ object Native {
      * @see BitwuzlaOption.BITWUZLA_OPT_INCREMENTAL
      * @see BitwuzlaResult
      */
+    @JvmStatic
     fun bitwuzlaCheckSatResult(bitwuzla: Bitwuzla): BitwuzlaResult =
         bitwuzlaCheckSat(bitwuzla).let { BitwuzlaResult.fromValue(it) }
 
@@ -966,6 +980,7 @@ object Native {
      *
      * @see bitwuzlaCheckSat
      * */
+    @JvmStatic
     fun bitwuzlaCheckSatTimeoutResult(bitwuzla: Bitwuzla, timeout: Long): BitwuzlaResult =
         bitwuzlaCheckSatTimeout(bitwuzla, timeout).let { BitwuzlaResult.fromValue(it) }
 
@@ -1072,6 +1087,7 @@ object Native {
      *
      * @see BitwuzlaKind
      */
+    @JvmStatic
     fun bitwuzlaTermGetBitwuzlaKind(term: BitwuzlaTerm): BitwuzlaKind =
         bitwuzlaTermGetKind(term).let { BitwuzlaKind.fromValue(it) }
 

--- a/ksmt-core/build.gradle.kts
+++ b/ksmt-core/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
 }
 
 dependencies {
-    api("it.unimi.dsi:fastutil-core:8.5.11")
-
     testImplementation(project(":ksmt-z3"))
     testImplementation("org.junit.jupiter", "junit-jupiter-params", "5.8.2")
 }

--- a/ksmt-core/build.gradle.kts
+++ b/ksmt-core/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 }
 
 dependencies {
+    api("it.unimi.dsi:fastutil-core:8.5.11")
+
     testImplementation(project(":ksmt-z3"))
     testImplementation("org.junit.jupiter", "junit-jupiter-params", "5.8.2")
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/Array.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/Array.kt
@@ -28,7 +28,7 @@ sealed class KArrayStoreBase<A : KArraySortBase<R>, R : KSort>(
     override val args: List<KExpr<KSort>>
         get() = buildList {
             add(array)
-            addAll(indices)
+            addAll(this@KArrayStoreBase.indices)
             add(value)
         }.uncheckedCast()
 }
@@ -131,7 +131,7 @@ sealed class KArraySelectBase<A : KArraySortBase<R>, R : KSort>(
     override val args: List<KExpr<KSort>>
         get() = buildList {
             add(array)
-            addAll(indices)
+            addAll(this@KArraySelectBase.indices)
         }.uncheckedCast()
 }
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/transformer/KNonRecursiveTransformerBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/transformer/KNonRecursiveTransformerBase.kt
@@ -168,7 +168,7 @@ abstract class KNonRecursiveTransformerBase: KTransformer {
         transformer: (List<KExpr<A>>) -> KExpr<T>
     ): KExpr<T> {
         val transformedDependencies = ArrayList<KExpr<A>>(dependencies.size)
-        val notTransformedDependencies = ArrayList<KExpr<A>>(dependencies.size)
+        var hasNonTransformedDependencies = false
 
         for (dependency in dependencies) {
             val transformedDependency = transformedExpr(dependency)
@@ -176,13 +176,16 @@ abstract class KNonRecursiveTransformerBase: KTransformer {
             if (transformedDependency != null) {
                 transformedDependencies += transformedDependency
                 continue
-            } else {
-                notTransformedDependencies += dependency
             }
+
+            if (!hasNonTransformedDependencies) {
+                hasNonTransformedDependencies = true
+                retryExprTransformation(expr)
+            }
+            transformExprDependencyIfNeeded(dependency, transformedDependency)
         }
 
-        if (notTransformedDependencies.isNotEmpty()) {
-            expr.transformAfter(notTransformedDependencies)
+        if (hasNonTransformedDependencies) {
             markExpressionAsNotTransformed()
 
             return expr

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprConverterBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprConverterBase.kt
@@ -1,6 +1,7 @@
 package org.ksmt.solver.util
 
 import org.ksmt.expr.KExpr
+import org.ksmt.solver.util.KExprConverterUtils.argumentsConversionRequired
 import org.ksmt.sort.KSort
 
 abstract class KExprConverterBase<T : Any> {
@@ -12,24 +13,35 @@ abstract class KExprConverterBase<T : Any> {
 
     val exprStack = arrayListOf<T>()
 
-    fun <S : KSort> T.convertFromNative(): KExpr<S> {
-        exprStack.add(this)
+    fun <S : KSort> T.convertFromNative(): KExpr<S> = conversionLoop(
+        stack = exprStack,
+        native = this,
+        stackPush = { stack, element -> stack.add(element) },
+        stackPop = { stack -> stack.removeLast() },
+        stackIsNotEmpty = { stack -> stack.isNotEmpty() },
+        convertNative = { expr -> convertNativeExpr(expr) },
+        findConverted = { expr -> findConvertedNative(expr) },
+        saveConverted = { expr, converted -> saveConvertedNative(expr, converted) }
+    )
 
-        while (exprStack.isNotEmpty()) {
-            val expr = exprStack.removeLast()
-
-            if (findConvertedNative(expr) != null) continue
-
-            val converted = convertNativeExpr(expr)
-
-            if (!converted.isArgumentsConversionRequired) {
-                saveConvertedNative(expr, converted.convertedExpr)
-            }
-        }
-
-        @Suppress("UNCHECKED_CAST")
-        return findConvertedNative(this) as? KExpr<S> ?: error("expr is not properly converted")
-    }
+    /**
+     * Ensure all expression arguments are already converted.
+     * Return converted arguments or null if not all arguments converted.
+     * */
+    fun ensureArgsConvertedAndConvert(
+        expr: T,
+        args: Array<T>,
+        expectedSize: Int
+    ): List<KExpr<*>>? = ensureArgsConvertedAndConvert(
+        stack = exprStack,
+        expr = expr,
+        args = args,
+        expectedSize = expectedSize,
+        arraySize = { it.size },
+        arrayGet = { array, idx -> array[idx] },
+        stackPush = { stack, element -> stack.add(element) },
+        findConverted = { findConvertedNative(it) }
+    )
 
     /**
      * Ensure all expression arguments are already converted.
@@ -41,31 +53,12 @@ abstract class KExprConverterBase<T : Any> {
         expectedSize: Int,
         converter: (List<KExpr<*>>) -> KExpr<*>
     ): ExprConversionResult {
-        checkArgumentsSizeMatchExpected(args.size, expectedSize)
-
-        val convertedArgs = mutableListOf<KExpr<*>>()
-        var hasNotConvertedArgs = false
-
-        for (arg in args) {
-            val converted = findConvertedNative(arg)
-
-            if (converted != null) {
-                convertedArgs.add(converted)
-                continue
-            }
-
-            if (!hasNotConvertedArgs) {
-                hasNotConvertedArgs = true
-                exprStack.add(expr)
-            }
-
-            exprStack.add(arg)
+        val convertedArgs = ensureArgsConvertedAndConvert(expr, args, expectedSize)
+        return if (convertedArgs == null) {
+            argumentsConversionRequired
+        } else {
+            ExprConversionResult(converter(convertedArgs))
         }
-
-        if (hasNotConvertedArgs) return argumentsConversionRequired
-
-        val convertedExpr = converter(convertedArgs)
-        return ExprConversionResult(convertedExpr)
     }
 
     inline fun <T : KSort> convert(op: () -> KExpr<T>) = ExprConversionResult(op())
@@ -125,26 +118,5 @@ abstract class KExprConverterBase<T : Any> {
         op: (KExpr<S>, KExpr<S>) -> KExpr<S>
     ) = ensureArgsConvertedAndConvert(this, args, expectedSize = args.size) { convertedArgs ->
         (convertedArgs as List<KExpr<S>>).reduce(op)
-    }
-
-    companion object {
-        @JvmInline
-        value class ExprConversionResult(private val expr: KExpr<*>?) {
-            val isArgumentsConversionRequired: Boolean
-                get() = expr == null
-
-            val convertedExpr: KExpr<*>
-                get() = expr ?: error("expr is not converted")
-        }
-
-        @JvmStatic
-        val argumentsConversionRequired = ExprConversionResult(null)
-
-        @JvmStatic
-        fun checkArgumentsSizeMatchExpected(argumentsSize: Int, expectedSize: Int) {
-            check(argumentsSize == expectedSize) {
-                "arguments size mismatch: expected $expectedSize, actual $argumentsSize"
-            }
-        }
     }
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprConverterBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprConverterBase.kt
@@ -41,13 +41,10 @@ abstract class KExprConverterBase<T : Any> {
         expectedSize: Int,
         converter: (List<KExpr<*>>) -> KExpr<*>
     ): ExprConversionResult {
-        check(args.size == expectedSize) {
-            "arguments size mismatch: expected $expectedSize, actual ${args.size}"
-        }
+        checkArgumentsSizeMatchExpected(args.size, expectedSize)
 
         val convertedArgs = mutableListOf<KExpr<*>>()
-        var exprAdded = false
-        var argsReady = true
+        var hasNotConvertedArgs = false
 
         for (arg in args) {
             val converted = findConvertedNative(arg)
@@ -57,17 +54,15 @@ abstract class KExprConverterBase<T : Any> {
                 continue
             }
 
-            argsReady = false
-
-            if (!exprAdded) {
+            if (!hasNotConvertedArgs) {
+                hasNotConvertedArgs = true
                 exprStack.add(expr)
-                exprAdded = true
             }
 
             exprStack.add(arg)
         }
 
-        if (!argsReady) return argumentsConversionRequired
+        if (hasNotConvertedArgs) return argumentsConversionRequired
 
         val convertedExpr = converter(convertedArgs)
         return ExprConversionResult(convertedExpr)
@@ -144,5 +139,12 @@ abstract class KExprConverterBase<T : Any> {
 
         @JvmStatic
         val argumentsConversionRequired = ExprConversionResult(null)
+
+        @JvmStatic
+        fun checkArgumentsSizeMatchExpected(argumentsSize: Int, expectedSize: Int) {
+            check(argumentsSize == expectedSize) {
+                "arguments size mismatch: expected $expectedSize, actual $argumentsSize"
+            }
+        }
     }
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprConverterUtils.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprConverterUtils.kt
@@ -1,0 +1,96 @@
+package org.ksmt.solver.util
+
+import org.ksmt.expr.KExpr
+import org.ksmt.solver.util.KExprConverterUtils.checkArgumentsSizeMatchExpected
+import org.ksmt.sort.KSort
+
+@Suppress("LongParameterList")
+inline fun <S : KSort, T, Stack> conversionLoop(
+    stack: Stack,
+    native: T,
+    stackPush: (Stack, T) -> Unit,
+    stackPop: (Stack) -> T,
+    stackIsNotEmpty: (Stack) -> Boolean,
+    convertNative: (T) -> ExprConversionResult,
+    findConverted: (T) -> KExpr<*>?,
+    saveConverted: (T, KExpr<*>) -> Unit
+): KExpr<S> {
+    stackPush(stack, native)
+
+    while (stackIsNotEmpty(stack)) {
+        val expr = stackPop(stack)
+
+        if (findConverted(expr) != null) continue
+
+        val converted = convertNative(expr)
+
+        if (!converted.isArgumentsConversionRequired) {
+            saveConverted(expr, converted.convertedExpr)
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return findConverted(native) as? KExpr<S> ?: error("expr is not properly converted")
+}
+
+/**
+ * Ensure all expression arguments are already converted.
+ * Return converted arguments or null if not all arguments converted.
+ * */
+@Suppress("LongParameterList")
+inline fun <T, TArray, Stack> ensureArgsConvertedAndConvert(
+    stack: Stack,
+    expr: T,
+    args: TArray,
+    expectedSize: Int,
+    stackPush: (Stack, T) -> Unit,
+    arraySize: (TArray) -> Int,
+    arrayGet: (TArray, Int) -> T,
+    findConverted: (T) -> KExpr<*>?,
+): List<KExpr<*>>? {
+    val argsSize = arraySize(args)
+    checkArgumentsSizeMatchExpected(argsSize, expectedSize)
+
+    val convertedArgs = mutableListOf<KExpr<*>>()
+    var hasNotConvertedArgs = false
+
+    for (i in 0 until argsSize) {
+        val arg = arrayGet(args, i)
+        val converted = findConverted(arg)
+
+        if (converted != null) {
+            convertedArgs.add(converted)
+            continue
+        }
+
+        if (!hasNotConvertedArgs) {
+            hasNotConvertedArgs = true
+            stackPush(stack, expr)
+        }
+
+        stackPush(stack, arg)
+    }
+
+    return if (hasNotConvertedArgs) null else convertedArgs
+}
+
+@JvmInline
+value class ExprConversionResult(private val expr: KExpr<*>?) {
+    val isArgumentsConversionRequired: Boolean
+        get() = expr == null
+
+    val convertedExpr: KExpr<*>
+        get() = expr ?: error("expr is not converted")
+}
+
+object KExprConverterUtils {
+    @JvmStatic
+    val argumentsConversionRequired = ExprConversionResult(null)
+
+    @JvmStatic
+    fun checkArgumentsSizeMatchExpected(argumentsSize: Int, expectedSize: Int) {
+        check(argumentsSize == expectedSize) {
+            "arguments size mismatch: expected $expectedSize, actual $argumentsSize"
+        }
+    }
+}

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprIntInternalizerBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprIntInternalizerBase.kt
@@ -6,7 +6,7 @@ import org.ksmt.solver.util.KExprLongInternalizerBase.Companion.NOT_INTERNALIZED
 import org.ksmt.sort.KSort
 
 /**
- * Specialized version of [KExprConverterBase] for Int native expressions.
+ * Specialized version of [KExprInternalizerBase] for Int native expressions.
  * */
 abstract class KExprIntInternalizerBase : KTransformerBase {
     @JvmField

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprIntInternalizerBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprIntInternalizerBase.kt
@@ -1,0 +1,188 @@
+package org.ksmt.solver.util
+
+import org.ksmt.expr.KExpr
+import org.ksmt.expr.transformer.KTransformerBase
+import org.ksmt.sort.KSort
+
+/**
+ * Specialized version of [KExprConverterBase] for Int native expressions.
+ * */
+abstract class KExprIntInternalizerBase : KTransformerBase {
+    @JvmField
+    val exprStack = arrayListOf<KExpr<*>>()
+
+    abstract fun findInternalizedExpr(expr: KExpr<*>): Int
+
+    abstract fun saveInternalizedExpr(expr: KExpr<*>, internalized: Int)
+
+    fun <S : KSort> KExpr<S>.internalizeExpr(): Int {
+        exprStack.add(this)
+
+        while (exprStack.isNotEmpty()) {
+            val expr = exprStack.removeLast()
+
+            val internalized = findInternalizedExpr(expr)
+            if (internalized != NOT_INTERNALIZED) continue
+
+            expr.accept(this@KExprIntInternalizerBase)
+        }
+
+        return findInternalizedExpr(this).also {
+            check(it != NOT_INTERNALIZED) { "expr is not properly internalized: $this" }
+        }
+    }
+
+    inline fun <S : KExpr<*>> S.transform(operation: () -> Int): S = also {
+        saveInternalizedExpr(this, operation())
+    }
+
+    inline fun <S : KExpr<*>> S.transform(
+        arg: KExpr<*>,
+        operation: (Int) -> Int
+    ): S = also {
+        val internalizedArg = findInternalizedExpr(arg)
+
+        if (internalizedArg == NOT_INTERNALIZED) {
+            exprStack.add(this)
+            exprStack.add(arg)
+        } else {
+            val internalized = operation(internalizedArg)
+            saveInternalizedExpr(this, internalized)
+        }
+    }
+
+    inline fun <S : KExpr<*>> S.transform(
+        arg0: KExpr<*>,
+        arg1: KExpr<*>,
+        operation: (Int, Int) -> Int
+    ): S = also {
+        val internalizedArg0 = findInternalizedExpr(arg0)
+        val internalizedArg1 = findInternalizedExpr(arg1)
+
+        if (internalizedArg0 == NOT_INTERNALIZED || internalizedArg1 == NOT_INTERNALIZED) {
+            exprStack.add(this)
+
+            if (internalizedArg0 == NOT_INTERNALIZED) {
+                exprStack.add(arg0)
+            }
+            if (internalizedArg1 == NOT_INTERNALIZED) {
+                exprStack.add(arg1)
+            }
+        } else {
+            val internalized = operation(internalizedArg0, internalizedArg1)
+            saveInternalizedExpr(this, internalized)
+        }
+    }
+
+    inline fun <S : KExpr<*>> S.transform(
+        arg0: KExpr<*>,
+        arg1: KExpr<*>,
+        arg2: KExpr<*>,
+        operation: (Int, Int, Int) -> Int
+    ): S = also {
+        val internalizedArg0 = findInternalizedExpr(arg0)
+        val internalizedArg1 = findInternalizedExpr(arg1)
+        val internalizedArg2 = findInternalizedExpr(arg2)
+
+        val someArgumentIsNotInternalzied =
+            internalizedArg0 == NOT_INTERNALIZED
+                    || internalizedArg1 == NOT_INTERNALIZED
+                    || internalizedArg2 == NOT_INTERNALIZED
+
+        if (someArgumentIsNotInternalzied) {
+            exprStack.add(this)
+
+            if (internalizedArg0 == NOT_INTERNALIZED) {
+                exprStack.add(arg0)
+            }
+            if (internalizedArg1 == NOT_INTERNALIZED) {
+                exprStack.add(arg1)
+            }
+            if (internalizedArg2 == NOT_INTERNALIZED) {
+                exprStack.add(arg2)
+            }
+        } else {
+            val internalized = operation(internalizedArg0, internalizedArg1, internalizedArg2)
+            saveInternalizedExpr(this, internalized)
+        }
+    }
+
+    inline fun <S : KExpr<*>> S.transform(
+        arg0: KExpr<*>,
+        arg1: KExpr<*>,
+        arg2: KExpr<*>,
+        arg3: KExpr<*>,
+        operation: (Int, Int, Int, Int) -> Int
+    ): S = also {
+        val internalizedArg0 = findInternalizedExpr(arg0)
+        val internalizedArg1 = findInternalizedExpr(arg1)
+        val internalizedArg2 = findInternalizedExpr(arg2)
+        val internalizedArg3 = findInternalizedExpr(arg3)
+
+        val someArgumentIsNotInternalzied =
+            internalizedArg0 == NOT_INTERNALIZED
+                    || internalizedArg1 == NOT_INTERNALIZED
+                    || internalizedArg2 == NOT_INTERNALIZED
+                    || internalizedArg3 == NOT_INTERNALIZED
+
+        if (someArgumentIsNotInternalzied) {
+            exprStack.add(this)
+
+            if (internalizedArg0 == NOT_INTERNALIZED) {
+                exprStack.add(arg0)
+            }
+            if (internalizedArg1 == NOT_INTERNALIZED) {
+                exprStack.add(arg1)
+            }
+            if (internalizedArg2 == NOT_INTERNALIZED) {
+                exprStack.add(arg2)
+            }
+            if (internalizedArg3 == NOT_INTERNALIZED) {
+                exprStack.add(arg3)
+            }
+        } else {
+
+            val internalized = operation(
+                internalizedArg0,
+                internalizedArg1,
+                internalizedArg2,
+                internalizedArg3
+            )
+            saveInternalizedExpr(this, internalized)
+        }
+    }
+
+    inline fun <S : KExpr<*>> S.transformList(
+        args: List<KExpr<*>>,
+        operation: (IntArray) -> Int
+    ): S = also {
+        val internalizedArgs = IntArray(args.size)
+        var hasNonInternalizedArgs = false
+
+        for (i in args.indices) {
+            val arg = args[i]
+            val internalized = findInternalizedExpr(arg)
+
+            if (internalized != NOT_INTERNALIZED) {
+                internalizedArgs[i] = internalized
+                continue
+            }
+
+            if (!hasNonInternalizedArgs) {
+                hasNonInternalizedArgs = true
+                exprStack.add(this)
+            }
+
+            exprStack.add(arg)
+        }
+
+        if (!hasNonInternalizedArgs) {
+            val internalized = operation(internalizedArgs)
+            saveInternalizedExpr(this, internalized)
+        }
+    }
+
+    companion object {
+        const val NOT_INTERNALIZED = -1
+    }
+}

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprIntInternalizerBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprIntInternalizerBase.kt
@@ -124,13 +124,13 @@ abstract class KExprIntInternalizerBase : KTransformerBase {
         val internalizedArg2 = findInternalizedExpr(arg2)
         val internalizedArg3 = findInternalizedExpr(arg3)
 
-        val someArgumentIsNotInternalzied =
+        val someArgumentIsNotInternalized =
             internalizedArg0 == NOT_INTERNALIZED
                     || internalizedArg1 == NOT_INTERNALIZED
                     || internalizedArg2 == NOT_INTERNALIZED
                     || internalizedArg3 == NOT_INTERNALIZED
 
-        if (someArgumentIsNotInternalzied) {
+        if (someArgumentIsNotInternalized) {
             exprStack.add(this)
 
             if (internalizedArg0 == NOT_INTERNALIZED) {

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprIntInternalizerBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprIntInternalizerBase.kt
@@ -2,6 +2,7 @@ package org.ksmt.solver.util
 
 import org.ksmt.expr.KExpr
 import org.ksmt.expr.transformer.KTransformerBase
+import org.ksmt.solver.util.KExprLongInternalizerBase.Companion.NOT_INTERNALIZED
 import org.ksmt.sort.KSort
 
 /**
@@ -11,6 +12,10 @@ abstract class KExprIntInternalizerBase : KTransformerBase {
     @JvmField
     val exprStack = arrayListOf<KExpr<*>>()
 
+    /**
+     * Return internalized expression or
+     * [NOT_INTERNALIZED] if expression was not internalized yet.
+     * */
     abstract fun findInternalizedExpr(expr: KExpr<*>): Int
 
     abstract fun saveInternalizedExpr(expr: KExpr<*>, internalized: Int)

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprIntInternalizerBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprIntInternalizerBase.kt
@@ -2,7 +2,6 @@ package org.ksmt.solver.util
 
 import org.ksmt.expr.KExpr
 import org.ksmt.expr.transformer.KTransformerBase
-import org.ksmt.solver.util.KExprLongInternalizerBase.Companion.NOT_INTERNALIZED
 import org.ksmt.sort.KSort
 
 /**
@@ -20,97 +19,60 @@ abstract class KExprIntInternalizerBase : KTransformerBase {
 
     abstract fun saveInternalizedExpr(expr: KExpr<*>, internalized: Int)
 
-    fun <S : KSort> KExpr<S>.internalizeExpr(): Int {
-        exprStack.add(this)
+    fun <S : KSort> KExpr<S>.internalizeExpr(): Int = internalizationLoop(
+        exprStack = exprStack,
+        initialExpr = this,
+        notInternalized = NOT_INTERNALIZED,
+        findInternalized = { findInternalizedExpr(it) }
+    )
 
-        while (exprStack.isNotEmpty()) {
-            val expr = exprStack.removeLast()
-
-            val internalized = findInternalizedExpr(expr)
-            if (internalized != NOT_INTERNALIZED) continue
-
-            expr.accept(this@KExprIntInternalizerBase)
-        }
-
-        return findInternalizedExpr(this).also {
-            check(it != NOT_INTERNALIZED) { "expr is not properly internalized: $this" }
-        }
-    }
-
-    inline fun <S : KExpr<*>> S.transform(operation: () -> Int): S = also {
-        saveInternalizedExpr(this, operation())
-    }
+    inline fun <S : KExpr<*>> S.transform(operation: () -> Int): S =
+        transform(
+            operation = { operation() },
+            saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized) }
+        )
 
     inline fun <S : KExpr<*>> S.transform(
         arg: KExpr<*>,
         operation: (Int) -> Int
-    ): S = also {
-        val internalizedArg = findInternalizedExpr(arg)
-
-        if (internalizedArg == NOT_INTERNALIZED) {
-            exprStack.add(this)
-            exprStack.add(arg)
-        } else {
-            val internalized = operation(internalizedArg)
-            saveInternalizedExpr(this, internalized)
-        }
-    }
+    ): S = transform(
+        exprStack = exprStack,
+        arg = arg,
+        operation = { operation(it) },
+        notInternalized = NOT_INTERNALIZED,
+        findInternalized = { findInternalizedExpr(it) },
+        saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized) }
+    )
 
     inline fun <S : KExpr<*>> S.transform(
         arg0: KExpr<*>,
         arg1: KExpr<*>,
         operation: (Int, Int) -> Int
-    ): S = also {
-        val internalizedArg0 = findInternalizedExpr(arg0)
-        val internalizedArg1 = findInternalizedExpr(arg1)
-
-        if (internalizedArg0 == NOT_INTERNALIZED || internalizedArg1 == NOT_INTERNALIZED) {
-            exprStack.add(this)
-
-            if (internalizedArg0 == NOT_INTERNALIZED) {
-                exprStack.add(arg0)
-            }
-            if (internalizedArg1 == NOT_INTERNALIZED) {
-                exprStack.add(arg1)
-            }
-        } else {
-            val internalized = operation(internalizedArg0, internalizedArg1)
-            saveInternalizedExpr(this, internalized)
-        }
-    }
+    ): S = transform(
+        exprStack = exprStack,
+        arg0 = arg0,
+        arg1 = arg1,
+        operation = { a0, a1 -> operation(a0, a1) },
+        notInternalized = NOT_INTERNALIZED,
+        findInternalized = { findInternalizedExpr(it) },
+        saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized) }
+    )
 
     inline fun <S : KExpr<*>> S.transform(
         arg0: KExpr<*>,
         arg1: KExpr<*>,
         arg2: KExpr<*>,
         operation: (Int, Int, Int) -> Int
-    ): S = also {
-        val internalizedArg0 = findInternalizedExpr(arg0)
-        val internalizedArg1 = findInternalizedExpr(arg1)
-        val internalizedArg2 = findInternalizedExpr(arg2)
-
-        val someArgumentIsNotInternalzied =
-            internalizedArg0 == NOT_INTERNALIZED
-                    || internalizedArg1 == NOT_INTERNALIZED
-                    || internalizedArg2 == NOT_INTERNALIZED
-
-        if (someArgumentIsNotInternalzied) {
-            exprStack.add(this)
-
-            if (internalizedArg0 == NOT_INTERNALIZED) {
-                exprStack.add(arg0)
-            }
-            if (internalizedArg1 == NOT_INTERNALIZED) {
-                exprStack.add(arg1)
-            }
-            if (internalizedArg2 == NOT_INTERNALIZED) {
-                exprStack.add(arg2)
-            }
-        } else {
-            val internalized = operation(internalizedArg0, internalizedArg1, internalizedArg2)
-            saveInternalizedExpr(this, internalized)
-        }
-    }
+    ): S = transform(
+        exprStack = exprStack,
+        arg0 = arg0,
+        arg1 = arg1,
+        arg2 = arg2,
+        operation = { a0, a1, a2 -> operation(a0, a1, a2) },
+        notInternalized = NOT_INTERNALIZED,
+        findInternalized = { findInternalizedExpr(it) },
+        saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized) }
+    )
 
     inline fun <S : KExpr<*>> S.transform(
         arg0: KExpr<*>,
@@ -118,74 +80,31 @@ abstract class KExprIntInternalizerBase : KTransformerBase {
         arg2: KExpr<*>,
         arg3: KExpr<*>,
         operation: (Int, Int, Int, Int) -> Int
-    ): S = also {
-        val internalizedArg0 = findInternalizedExpr(arg0)
-        val internalizedArg1 = findInternalizedExpr(arg1)
-        val internalizedArg2 = findInternalizedExpr(arg2)
-        val internalizedArg3 = findInternalizedExpr(arg3)
-
-        val someArgumentIsNotInternalized =
-            internalizedArg0 == NOT_INTERNALIZED
-                    || internalizedArg1 == NOT_INTERNALIZED
-                    || internalizedArg2 == NOT_INTERNALIZED
-                    || internalizedArg3 == NOT_INTERNALIZED
-
-        if (someArgumentIsNotInternalized) {
-            exprStack.add(this)
-
-            if (internalizedArg0 == NOT_INTERNALIZED) {
-                exprStack.add(arg0)
-            }
-            if (internalizedArg1 == NOT_INTERNALIZED) {
-                exprStack.add(arg1)
-            }
-            if (internalizedArg2 == NOT_INTERNALIZED) {
-                exprStack.add(arg2)
-            }
-            if (internalizedArg3 == NOT_INTERNALIZED) {
-                exprStack.add(arg3)
-            }
-        } else {
-
-            val internalized = operation(
-                internalizedArg0,
-                internalizedArg1,
-                internalizedArg2,
-                internalizedArg3
-            )
-            saveInternalizedExpr(this, internalized)
-        }
-    }
+    ): S = transform(
+        exprStack = exprStack,
+        arg0 = arg0,
+        arg1 = arg1,
+        arg2 = arg2,
+        arg3 = arg3,
+        operation = { a0, a1, a2, a3 -> operation(a0, a1, a2, a3) },
+        notInternalized = NOT_INTERNALIZED,
+        findInternalized = { findInternalizedExpr(it) },
+        saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized) }
+    )
 
     inline fun <S : KExpr<*>> S.transformList(
         args: List<KExpr<*>>,
         operation: (IntArray) -> Int
-    ): S = also {
-        val internalizedArgs = IntArray(args.size)
-        var hasNonInternalizedArgs = false
-
-        for (i in args.indices) {
-            val arg = args[i]
-            val internalized = findInternalizedExpr(arg)
-
-            if (internalized != NOT_INTERNALIZED) {
-                internalizedArgs[i] = internalized
-                continue
-            }
-
-            if (!hasNonInternalizedArgs) {
-                hasNonInternalizedArgs = true
-                exprStack.add(this)
-            }
-
-            exprStack.add(arg)
-        }
-
-        if (!hasNonInternalizedArgs) {
-            val internalized = operation(internalizedArgs)
-            saveInternalizedExpr(this, internalized)
-        }
-    }
+    ): S = transformList(
+        exprStack = exprStack,
+        args = args,
+        operation = { transformedArgs -> operation(transformedArgs) },
+        mkArray = { size -> IntArray(size) },
+        setArray = { array, idx, value -> array[idx] = value },
+        notInternalized = NOT_INTERNALIZED,
+        findInternalized = { findInternalizedExpr(it) },
+        saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized) }
+    )
 
     companion object {
         const val NOT_INTERNALIZED = -1

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprInternalizerBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprInternalizerBase.kt
@@ -3,7 +3,6 @@ package org.ksmt.solver.util
 import org.ksmt.expr.KExpr
 import org.ksmt.expr.transformer.KTransformerBase
 import org.ksmt.sort.KSort
-import org.ksmt.utils.uncheckedCast
 
 abstract class KExprInternalizerBase<T : Any> : KTransformerBase {
     @JvmField
@@ -13,85 +12,60 @@ abstract class KExprInternalizerBase<T : Any> : KTransformerBase {
 
     abstract fun saveInternalizedExpr(expr: KExpr<*>, internalized: T)
 
-    fun <S : KSort> KExpr<S>.internalizeExpr(): T {
-        exprStack.add(this)
+    fun <S : KSort> KExpr<S>.internalizeExpr(): T =
+        internalizationLoop(
+            exprStack = exprStack,
+            initialExpr = this,
+            notInternalized = null,
+            findInternalized = { findInternalizedExpr(it) }
+        )!!
 
-        while (exprStack.isNotEmpty()) {
-            val expr = exprStack.removeLast()
-
-            val internalized = findInternalizedExpr(expr)
-            if (internalized != null) continue
-
-            /**
-             * Internalize expression non-recursively.
-             * 1. Ensure all expression arguments are internalized.
-             * If not so, internalize arguments first
-             * 2. Internalize expression if all arguments are available
-             * */
-            expr.accept(this@KExprInternalizerBase)
-        }
-        return findInternalizedExpr(this) ?: error("expr is not properly internalized: $this")
-    }
-
-    inline fun <S : KExpr<*>> S.transform(operation: () -> T): S = also {
-        saveInternalizedExpr(this, operation())
-    }
+    inline fun <S : KExpr<*>> S.transform(operation: () -> T): S = transform(
+        operation = { operation() },
+        saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized) }
+    )
 
     inline fun <reified A0 : T, S : KExpr<*>> S.transform(
         arg: KExpr<*>,
         operation: (A0) -> T
-    ): S = also {
-        val internalizedArg = findInternalizedExpr(arg)
-
-        if (internalizedArg == null) {
-            exprStack.add(this)
-            exprStack.add(arg)
-        } else {
-            val internalized = operation(internalizedArg as A0)
-            saveInternalizedExpr(this, internalized)
-        }
-    }
+    ): S = transform(
+        exprStack = exprStack,
+        arg = arg,
+        operation = { operation(it as A0) },
+        notInternalized = null,
+        findInternalized = { findInternalizedExpr(it) },
+        saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized!!) }
+    )
 
     inline fun <reified A0 : T, reified A1 : T, S : KExpr<*>> S.transform(
         arg0: KExpr<*>,
         arg1: KExpr<*>,
         operation: (A0, A1) -> T
-    ): S = also {
-        val internalizedArg0 = findInternalizedExpr(arg0)
-        val internalizedArg1 = findInternalizedExpr(arg1)
-
-        if (internalizedArg0 == null || internalizedArg1 == null) {
-            exprStack.add(this)
-            internalizedArg0 ?: exprStack.add(arg0)
-            internalizedArg1 ?: exprStack.add(arg1)
-        } else {
-            val internalized = operation(internalizedArg0 as A0, internalizedArg1 as A1)
-            saveInternalizedExpr(this, internalized)
-        }
-    }
+    ): S = transform(
+        exprStack = exprStack,
+        arg0 = arg0,
+        arg1 = arg1,
+        operation = { a0, a1 -> operation(a0 as A0, a1 as A1) },
+        notInternalized = null,
+        findInternalized = { findInternalizedExpr(it) },
+        saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized!!) }
+    )
 
     inline fun <reified A0 : T, reified A1 : T, reified A2 : T, S : KExpr<*>> S.transform(
         arg0: KExpr<*>,
         arg1: KExpr<*>,
         arg2: KExpr<*>,
         operation: (A0, A1, A2) -> T
-    ): S = also {
-        val internalizedArg0 = findInternalizedExpr(arg0)
-        val internalizedArg1 = findInternalizedExpr(arg1)
-        val internalizedArg2 = findInternalizedExpr(arg2)
-
-        val someArgumentIsNull = internalizedArg0 == null || internalizedArg1 == null || internalizedArg2 == null
-
-        if (someArgumentIsNull) {
-            exprStack.add(this)
-            internalizedArg0 ?: exprStack.add(arg0)
-            internalizedArg1 ?: exprStack.add(arg1)
-            internalizedArg2 ?: exprStack.add(arg2)
-        } else {
-            val internalized = operation(internalizedArg0 as A0, internalizedArg1 as A1, internalizedArg2 as A2)
-            saveInternalizedExpr(this, internalized)
-        }
-    }
+    ): S = transform(
+        exprStack = exprStack,
+        arg0 = arg0,
+        arg1 = arg1,
+        arg2 = arg2,
+        operation = { a0, a1, a2 -> operation(a0 as A0, a1 as A1, a2 as A2) },
+        notInternalized = null,
+        findInternalized = { findInternalizedExpr(it) },
+        saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized!!) }
+    )
 
     inline fun <reified A0 : T, reified A1 : T, reified A2 : T, reified A3 : T, S : KExpr<*>> S.transform(
         arg0: KExpr<*>,
@@ -99,63 +73,32 @@ abstract class KExprInternalizerBase<T : Any> : KTransformerBase {
         arg2: KExpr<*>,
         arg3: KExpr<*>,
         operation: (A0, A1, A2, A3) -> T
-    ): S = also {
-        val internalizedArg0 = findInternalizedExpr(arg0)
-        val internalizedArg1 = findInternalizedExpr(arg1)
-        val internalizedArg2 = findInternalizedExpr(arg2)
-        val internalizedArg3 = findInternalizedExpr(arg3)
-
-        val someArgumentIsNull =
-            internalizedArg0 == null
-                    || internalizedArg1 == null
-                    || internalizedArg2 == null
-                    || internalizedArg3 == null
-
-        if (someArgumentIsNull) {
-            exprStack.add(this)
-
-            internalizedArg0 ?: exprStack.add(arg0)
-            internalizedArg1 ?: exprStack.add(arg1)
-            internalizedArg2 ?: exprStack.add(arg2)
-            internalizedArg3 ?: exprStack.add(arg3)
-        } else {
-            val internalized = operation(
-                internalizedArg0 as A0,
-                internalizedArg1 as A1,
-                internalizedArg2 as A2,
-                internalizedArg3 as A3
-            )
-            saveInternalizedExpr(this, internalized)
-        }
-    }
+    ): S = transform(
+        exprStack = exprStack,
+        arg0 = arg0,
+        arg1 = arg1,
+        arg2 = arg2,
+        arg3 = arg3,
+        operation = { a0, a1, a2, a3 -> operation(a0 as A0, a1 as A1, a2 as A2, a3 as A3) },
+        notInternalized = null,
+        findInternalized = { findInternalizedExpr(it) },
+        saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized!!) }
+    )
 
     inline fun <reified A : T, S : KExpr<*>> S.transformList(
         args: List<KExpr<*>>,
         operation: (Array<A>) -> T
-    ): S = also {
-        val internalizedArgs = arrayOfNulls<A>(args.size)
-        var hasNonInternalizedArgs = false
-
-        for (i in args.indices) {
-            val arg = args[i]
-            val internalized = findInternalizedExpr(arg)
-
-            if (internalized != null) {
-                internalizedArgs[i] = internalized as A
-                continue
-            }
-
-            if (!hasNonInternalizedArgs) {
-                hasNonInternalizedArgs = true
-                exprStack.add(this)
-            }
-
-            exprStack.add(arg)
-        }
-
-        if (!hasNonInternalizedArgs) {
-            val internalized = operation(internalizedArgs.uncheckedCast())
-            saveInternalizedExpr(this, internalized)
-        }
-    }
+    ): S = transformList(
+        exprStack = exprStack,
+        args = args,
+        operation = { transformedArgs ->
+            @Suppress("UNCHECKED_CAST")
+            operation(transformedArgs as Array<A>)
+        },
+        mkArray = { size -> arrayOfNulls<A>(size) },
+        setArray = { array, idx, value -> array[idx] = value as A },
+        notInternalized = null,
+        findInternalized = { findInternalizedExpr(it) },
+        saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized!!) }
+    )
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprInternalizerBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprInternalizerBase.kt
@@ -2,17 +2,12 @@ package org.ksmt.solver.util
 
 import org.ksmt.expr.KExpr
 import org.ksmt.expr.transformer.KTransformerBase
-import org.ksmt.solver.util.KExprInternalizerBase.ExprInternalizationResult.Companion.argumentsInternalizationRequired
-import org.ksmt.solver.util.KExprInternalizerBase.ExprInternalizationResult.Companion.notInitializedInternalizationResult
 import org.ksmt.sort.KSort
+import org.ksmt.utils.uncheckedCast
 
 abstract class KExprInternalizerBase<T : Any> : KTransformerBase {
+    @JvmField
     val exprStack = arrayListOf<KExpr<*>>()
-
-    /**
-     * Keeps result of last [KTransformerBase.transform] invocation.
-     * */
-    var lastExprInternalizationResult: ExprInternalizationResult = notInitializedInternalizationResult
 
     abstract fun findInternalizedExpr(expr: KExpr<*>): T?
 
@@ -22,7 +17,6 @@ abstract class KExprInternalizerBase<T : Any> : KTransformerBase {
         exprStack.add(this)
 
         while (exprStack.isNotEmpty()) {
-            lastExprInternalizationResult = notInitializedInternalizationResult
             val expr = exprStack.removeLast()
 
             val internalized = findInternalizedExpr(expr)
@@ -31,29 +25,16 @@ abstract class KExprInternalizerBase<T : Any> : KTransformerBase {
             /**
              * Internalize expression non-recursively.
              * 1. Ensure all expression arguments are internalized.
-             * If not so, [lastExprInternalizationResult] is set to [argumentsInternalizationRequired]
-             * 2. Internalize expression if all arguments are available and
-             * set [lastExprInternalizationResult] to internalization result.
+             * If not so, internalize arguments first
+             * 2. Internalize expression if all arguments are available
              * */
             expr.accept(this@KExprInternalizerBase)
-
-            check(!lastExprInternalizationResult.notInitialized) {
-                "Internalization result wasn't initialized during expr internalization"
-            }
-
-            if (!lastExprInternalizationResult.isArgumentsInternalizationRequired) {
-                saveInternalizedExpr(expr, lastExprInternalizationResult.internalizedExpr())
-            }
         }
         return findInternalizedExpr(this) ?: error("expr is not properly internalized: $this")
     }
 
-    @Suppress("UNCHECKED_CAST")
-    fun ExprInternalizationResult.internalizedExpr(): T =
-        internalizedExprInternal as? T ?: error("expr is not internalized")
-
     inline fun <S : KExpr<*>> S.transform(operation: () -> T): S = also {
-        lastExprInternalizationResult = ExprInternalizationResult(operation())
+        saveInternalizedExpr(this, operation())
     }
 
     inline fun <reified A0 : T, S : KExpr<*>> S.transform(
@@ -62,12 +43,12 @@ abstract class KExprInternalizerBase<T : Any> : KTransformerBase {
     ): S = also {
         val internalizedArg = findInternalizedExpr(arg)
 
-        lastExprInternalizationResult = if (internalizedArg == null) {
+        if (internalizedArg == null) {
             exprStack.add(this)
             exprStack.add(arg)
-            argumentsInternalizationRequired
         } else {
-            ExprInternalizationResult(operation(internalizedArg as A0))
+            val internalized = operation(internalizedArg as A0)
+            saveInternalizedExpr(this, internalized)
         }
     }
 
@@ -79,15 +60,13 @@ abstract class KExprInternalizerBase<T : Any> : KTransformerBase {
         val internalizedArg0 = findInternalizedExpr(arg0)
         val internalizedArg1 = findInternalizedExpr(arg1)
 
-        lastExprInternalizationResult = if (internalizedArg0 == null || internalizedArg1 == null) {
+        if (internalizedArg0 == null || internalizedArg1 == null) {
             exprStack.add(this)
             internalizedArg0 ?: exprStack.add(arg0)
             internalizedArg1 ?: exprStack.add(arg1)
-            argumentsInternalizationRequired
         } else {
-            ExprInternalizationResult(
-                operation(internalizedArg0 as A0, internalizedArg1 as A1)
-            )
+            val internalized = operation(internalizedArg0 as A0, internalizedArg1 as A1)
+            saveInternalizedExpr(this, internalized)
         }
     }
 
@@ -103,16 +82,14 @@ abstract class KExprInternalizerBase<T : Any> : KTransformerBase {
 
         val someArgumentIsNull = internalizedArg0 == null || internalizedArg1 == null || internalizedArg2 == null
 
-        lastExprInternalizationResult = if (someArgumentIsNull) {
+        if (someArgumentIsNull) {
             exprStack.add(this)
             internalizedArg0 ?: exprStack.add(arg0)
             internalizedArg1 ?: exprStack.add(arg1)
             internalizedArg2 ?: exprStack.add(arg2)
-            argumentsInternalizationRequired
         } else {
-            ExprInternalizationResult(
-                operation(internalizedArg0 as A0, internalizedArg1 as A1, internalizedArg2 as A2)
-            )
+            val internalized = operation(internalizedArg0 as A0, internalizedArg1 as A1, internalizedArg2 as A2)
+            saveInternalizedExpr(this, internalized)
         }
     }
 
@@ -128,8 +105,11 @@ abstract class KExprInternalizerBase<T : Any> : KTransformerBase {
         val internalizedArg2 = findInternalizedExpr(arg2)
         val internalizedArg3 = findInternalizedExpr(arg3)
 
-        val args = listOf(internalizedArg0, internalizedArg1, internalizedArg2, internalizedArg3)
-        val someArgumentIsNull = args.any { it == null }
+        val someArgumentIsNull =
+            internalizedArg0 == null
+                    || internalizedArg1 == null
+                    || internalizedArg2 == null
+                    || internalizedArg3 == null
 
         if (someArgumentIsNull) {
             exprStack.add(this)
@@ -138,17 +118,14 @@ abstract class KExprInternalizerBase<T : Any> : KTransformerBase {
             internalizedArg1 ?: exprStack.add(arg1)
             internalizedArg2 ?: exprStack.add(arg2)
             internalizedArg3 ?: exprStack.add(arg3)
-
-            lastExprInternalizationResult = argumentsInternalizationRequired
         } else {
-            lastExprInternalizationResult = ExprInternalizationResult(
-                operation(
-                    internalizedArg0 as A0,
-                    internalizedArg1 as A1,
-                    internalizedArg2 as A2,
-                    internalizedArg3 as A3
-                )
+            val internalized = operation(
+                internalizedArg0 as A0,
+                internalizedArg1 as A1,
+                internalizedArg2 as A2,
+                internalizedArg3 as A3
             )
+            saveInternalizedExpr(this, internalized)
         }
     }
 
@@ -156,52 +133,29 @@ abstract class KExprInternalizerBase<T : Any> : KTransformerBase {
         args: List<KExpr<*>>,
         operation: (Array<A>) -> T
     ): S = also {
-        val internalizedArgs = mutableListOf<A>()
-        var exprAdded = false
-        var argsReady = true
+        val internalizedArgs = arrayOfNulls<A>(args.size)
+        var hasNonInternalizedArgs = false
 
-        for (arg in args) {
+        for (i in args.indices) {
+            val arg = args[i]
             val internalized = findInternalizedExpr(arg)
 
             if (internalized != null) {
-                internalizedArgs.add(internalized as A)
+                internalizedArgs[i] = internalized as A
                 continue
             }
 
-            argsReady = false
-
-            if (!exprAdded) {
+            if (!hasNonInternalizedArgs) {
+                hasNonInternalizedArgs = true
                 exprStack.add(this)
-                exprAdded = true
             }
 
             exprStack.add(arg)
         }
 
-        lastExprInternalizationResult = if (argsReady) {
-            ExprInternalizationResult(operation(internalizedArgs.toTypedArray()))
-        } else {
-            argumentsInternalizationRequired
-        }
-    }
-
-    @JvmInline
-    value class ExprInternalizationResult(private val value: Any) {
-        val isArgumentsInternalizationRequired: Boolean
-            get() = value === argumentsInternalizationRequiredMarker
-
-        val notInitialized: Boolean
-            get() = value === notInitializedInternalizationResultMarker
-
-        val internalizedExprInternal: Any
-            get() = value
-
-        companion object {
-            private val argumentsInternalizationRequiredMarker = Any()
-            private val notInitializedInternalizationResultMarker = Any()
-            val argumentsInternalizationRequired = ExprInternalizationResult(argumentsInternalizationRequiredMarker)
-            val notInitializedInternalizationResult =
-                ExprInternalizationResult(notInitializedInternalizationResultMarker)
+        if (!hasNonInternalizedArgs) {
+            val internalized = operation(internalizedArgs.uncheckedCast())
+            saveInternalizedExpr(this, internalized)
         }
     }
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprInternalizerUtils.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprInternalizerUtils.kt
@@ -53,8 +53,7 @@ inline fun <S : KExpr<*>, T> S.transform(
         exprStack.add(this)
         exprStack.add(arg)
     } else {
-        val internalized = operation(internalizedArg)
-        saveInternalized(this, internalized)
+        saveInternalized(this, operation(internalizedArg))
     }
 }
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprInternalizerUtils.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprInternalizerUtils.kt
@@ -1,0 +1,212 @@
+package org.ksmt.solver.util
+
+import org.ksmt.expr.KExpr
+import org.ksmt.expr.transformer.KTransformerBase
+
+inline fun <T> KTransformerBase.internalizationLoop(
+    exprStack: MutableList<KExpr<*>>,
+    initialExpr: KExpr<*>,
+    notInternalized: T,
+    findInternalized: (KExpr<*>) -> T
+): T {
+    exprStack.add(initialExpr)
+
+    while (exprStack.isNotEmpty()) {
+        val expr = exprStack.removeLast()
+
+        val internalized = findInternalized(expr)
+        if (internalized != notInternalized) continue
+
+        /**
+         * Internalize expression non-recursively.
+         * 1. Ensure all expression arguments are internalized.
+         * If not so, internalize arguments first
+         * 2. Internalize expression if all arguments are available
+         * */
+        expr.accept(this)
+    }
+
+    return findInternalized(initialExpr).also {
+        check(it != notInternalized) { "expr is not properly internalized: $initialExpr" }
+    }
+}
+
+inline fun <S : KExpr<*>, T> S.transform(
+    operation: () -> T,
+    saveInternalized: (KExpr<*>, T) -> Unit
+): S = also {
+    saveInternalized(this, operation())
+}
+
+@Suppress("LongParameterList")
+inline fun <S : KExpr<*>, T> S.transform(
+    exprStack: MutableList<KExpr<*>>,
+    arg: KExpr<*>,
+    operation: (T) -> T,
+    notInternalized: T,
+    findInternalized: (KExpr<*>) -> T,
+    saveInternalized: (KExpr<*>, T) -> Unit
+): S = also {
+    val internalizedArg = findInternalized(arg)
+
+    if (internalizedArg == notInternalized) {
+        exprStack.add(this)
+        exprStack.add(arg)
+    } else {
+        val internalized = operation(internalizedArg)
+        saveInternalized(this, internalized)
+    }
+}
+
+@Suppress("LongParameterList")
+inline fun <S : KExpr<*>, T> S.transform(
+    exprStack: MutableList<KExpr<*>>,
+    arg0: KExpr<*>,
+    arg1: KExpr<*>,
+    operation: (T, T) -> T,
+    notInternalized: T,
+    findInternalized: (KExpr<*>) -> T,
+    saveInternalized: (KExpr<*>, T) -> Unit
+): S = also {
+    val internalizedArg0 = findInternalized(arg0)
+    val internalizedArg1 = findInternalized(arg1)
+
+    if (internalizedArg0 == notInternalized || internalizedArg1 == notInternalized) {
+        exprStack.add(this)
+
+        if (internalizedArg0 == notInternalized) {
+            exprStack.add(arg0)
+        }
+        if (internalizedArg1 == notInternalized) {
+            exprStack.add(arg1)
+        }
+    } else {
+        val internalized = operation(internalizedArg0, internalizedArg1)
+        saveInternalized(this, internalized)
+    }
+}
+
+@Suppress("LongParameterList")
+inline fun <S : KExpr<*>, T> S.transform(
+    exprStack: MutableList<KExpr<*>>,
+    arg0: KExpr<*>,
+    arg1: KExpr<*>,
+    arg2: KExpr<*>,
+    operation: (T, T, T) -> T,
+    notInternalized: T,
+    findInternalized: (KExpr<*>) -> T,
+    saveInternalized: (KExpr<*>, T) -> Unit
+): S = also {
+    val internalizedArg0 = findInternalized(arg0)
+    val internalizedArg1 = findInternalized(arg1)
+    val internalizedArg2 = findInternalized(arg2)
+
+    val someArgumentIsNotInternalized =
+        internalizedArg0 == notInternalized
+                || internalizedArg1 == notInternalized
+                || internalizedArg2 == notInternalized
+
+    if (someArgumentIsNotInternalized) {
+        exprStack.add(this)
+
+        if (internalizedArg0 == notInternalized) {
+            exprStack.add(arg0)
+        }
+        if (internalizedArg1 == notInternalized) {
+            exprStack.add(arg1)
+        }
+        if (internalizedArg2 == notInternalized) {
+            exprStack.add(arg2)
+        }
+    } else {
+        val internalized = operation(internalizedArg0, internalizedArg1, internalizedArg2)
+        saveInternalized(this, internalized)
+    }
+}
+
+@Suppress("LongParameterList")
+inline fun <S : KExpr<*>, T> S.transform(
+    exprStack: MutableList<KExpr<*>>,
+    arg0: KExpr<*>,
+    arg1: KExpr<*>,
+    arg2: KExpr<*>,
+    arg3: KExpr<*>,
+    operation: (T, T, T, T) -> T,
+    notInternalized: T,
+    findInternalized: (KExpr<*>) -> T,
+    saveInternalized: (KExpr<*>, T) -> Unit
+): S = also {
+    val internalizedArg0 = findInternalized(arg0)
+    val internalizedArg1 = findInternalized(arg1)
+    val internalizedArg2 = findInternalized(arg2)
+    val internalizedArg3 = findInternalized(arg3)
+
+    val someArgumentIsNotInternalized =
+        internalizedArg0 == notInternalized
+                || internalizedArg1 == notInternalized
+                || internalizedArg2 == notInternalized
+                || internalizedArg3 == notInternalized
+
+    if (someArgumentIsNotInternalized) {
+        exprStack.add(this)
+
+        if (internalizedArg0 == notInternalized) {
+            exprStack.add(arg0)
+        }
+        if (internalizedArg1 == notInternalized) {
+            exprStack.add(arg1)
+        }
+        if (internalizedArg2 == notInternalized) {
+            exprStack.add(arg2)
+        }
+        if (internalizedArg3 == notInternalized) {
+            exprStack.add(arg3)
+        }
+    } else {
+
+        val internalized = operation(
+            internalizedArg0,
+            internalizedArg1,
+            internalizedArg2,
+            internalizedArg3
+        )
+        saveInternalized(this, internalized)
+    }
+}
+
+@Suppress("LongParameterList")
+inline fun <S : KExpr<*>, T, A> S.transformList(
+    exprStack: MutableList<KExpr<*>>,
+    args: List<KExpr<*>>,
+    operation: (A) -> T,
+    mkArray: (Int) -> A,
+    setArray: (A, Int, T) -> Unit,
+    notInternalized: T,
+    findInternalized: (KExpr<*>) -> T,
+    saveInternalized: (KExpr<*>, T) -> Unit
+): S = also {
+    val internalizedArgs = mkArray(args.size)
+    var hasNonInternalizedArgs = false
+
+    for (i in args.indices) {
+        val arg = args[i]
+        val internalized = findInternalized(arg)
+
+        if (internalized != notInternalized) {
+            setArray(internalizedArgs, i, internalized)
+            continue
+        }
+
+        if (!hasNonInternalizedArgs) {
+            hasNonInternalizedArgs = true
+            exprStack.add(this)
+        }
+
+        exprStack.add(arg)
+    }
+
+    if (!hasNonInternalizedArgs) {
+        val internalized = operation(internalizedArgs)
+        saveInternalized(this, internalized)
+    }
+}

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongConverterBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongConverterBase.kt
@@ -6,6 +6,9 @@ import org.ksmt.solver.util.KExprConverterBase.Companion.argumentsConversionRequ
 import org.ksmt.solver.util.KExprConverterBase.Companion.checkArgumentsSizeMatchExpected
 import org.ksmt.sort.KSort
 
+/**
+ * Specialized version of [KExprConverterBase] for Long native expressions.
+ * */
 abstract class KExprLongConverterBase {
     abstract fun findConvertedNative(expr: Long): KExpr<*>?
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongConverterBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongConverterBase.kt
@@ -1,5 +1,6 @@
 package org.ksmt.solver.util
 
+import it.unimi.dsi.fastutil.longs.LongArrayList
 import org.ksmt.expr.KExpr
 import org.ksmt.solver.util.KExprConverterBase.Companion.ExprConversionResult
 import org.ksmt.solver.util.KExprConverterBase.Companion.argumentsConversionRequired
@@ -17,13 +18,13 @@ abstract class KExprLongConverterBase {
     abstract fun convertNativeExpr(expr: Long): ExprConversionResult
 
     @JvmField
-    val exprStack = arrayListOf<Long>()
+    val exprStack = LongArrayList()
 
     fun <S : KSort> convertFromNative(native: Long): KExpr<S> {
         exprStack.add(native)
 
         while (exprStack.isNotEmpty()) {
-            val expr = exprStack.removeLast()
+            val expr = exprStack.removeLong(exprStack.lastIndex)
 
             if (findConvertedNative(expr) != null) continue
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongConverterBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongConverterBase.kt
@@ -3,6 +3,7 @@ package org.ksmt.solver.util
 import org.ksmt.expr.KExpr
 import org.ksmt.solver.util.KExprConverterBase.Companion.ExprConversionResult
 import org.ksmt.solver.util.KExprConverterBase.Companion.argumentsConversionRequired
+import org.ksmt.solver.util.KExprConverterBase.Companion.checkArgumentsSizeMatchExpected
 import org.ksmt.sort.KSort
 
 abstract class KExprLongConverterBase {
@@ -34,12 +35,6 @@ abstract class KExprLongConverterBase {
         return findConvertedNative(native) as? KExpr<S> ?: error("expr is not properly converted")
     }
 
-    fun checkArgumentsSizeMatchExpected(args: LongArray, expectedSize: Int) {
-        check(args.size == expectedSize) {
-            "arguments size mismatch: expected $expectedSize, actual ${args.size}"
-        }
-    }
-
     /**
      * Ensure all expression arguments are already converted.
      * If not so, [argumentsConversionRequired] is returned.
@@ -50,7 +45,7 @@ abstract class KExprLongConverterBase {
         expectedSize: Int,
         converter: (List<KExpr<*>>) -> KExpr<*>
     ): ExprConversionResult {
-        checkArgumentsSizeMatchExpected(args, expectedSize)
+        checkArgumentsSizeMatchExpected(args.size, expectedSize)
 
         val convertedArgs = mutableListOf<KExpr<*>>()
         var hasNotConvertedArgs = false

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongInternalizerBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongInternalizerBase.kt
@@ -11,6 +11,10 @@ abstract class KExprLongInternalizerBase : KTransformerBase {
     @JvmField
     val exprStack = arrayListOf<KExpr<*>>()
 
+    /**
+     * Return internalized expression or
+     * [NOT_INTERNALIZED] if expression was not internalized yet.
+     * */
     abstract fun findInternalizedExpr(expr: KExpr<*>): Long
 
     abstract fun saveInternalizedExpr(expr: KExpr<*>, internalized: Long)

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongInternalizerBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongInternalizerBase.kt
@@ -1,0 +1,186 @@
+package org.ksmt.solver.util
+
+import org.ksmt.expr.KExpr
+import org.ksmt.expr.transformer.KTransformerBase
+import org.ksmt.sort.KSort
+
+abstract class KExprLongInternalizerBase : KTransformerBase {
+    @JvmField
+    val exprStack = arrayListOf<KExpr<*>>()
+
+    abstract fun findInternalizedExpr(expr: KExpr<*>): Long
+
+    abstract fun saveInternalizedExpr(expr: KExpr<*>, internalized: Long)
+
+    fun <S : KSort> KExpr<S>.internalizeExpr(): Long {
+        exprStack.add(this)
+
+        while (exprStack.isNotEmpty()) {
+            val expr = exprStack.removeLast()
+
+            val internalized = findInternalizedExpr(expr)
+            if (internalized != NOT_INTERNALIZED) continue
+
+            expr.accept(this@KExprLongInternalizerBase)
+        }
+
+        return findInternalizedExpr(this).also {
+            check(it != NOT_INTERNALIZED) { "expr is not properly internalized: $this" }
+        }
+    }
+
+    inline fun <S : KExpr<*>> S.transform(operation: () -> Long): S = also {
+        val internalized = operation()
+        saveInternalizedExpr(this, internalized)
+    }
+
+    inline fun <S : KExpr<*>> S.transform(
+        arg: KExpr<*>,
+        operation: (Long) -> Long
+    ): S = also {
+        val internalizedArg = findInternalizedExpr(arg)
+
+        if (internalizedArg == NOT_INTERNALIZED) {
+            exprStack.add(this)
+            exprStack.add(arg)
+        } else {
+            val internalized = operation(internalizedArg)
+            saveInternalizedExpr(this, internalized)
+        }
+    }
+
+    inline fun <S : KExpr<*>> S.transform(
+        arg0: KExpr<*>,
+        arg1: KExpr<*>,
+        operation: (Long, Long) -> Long
+    ): S = also {
+        val internalizedArg0 = findInternalizedExpr(arg0)
+        val internalizedArg1 = findInternalizedExpr(arg1)
+
+        if (internalizedArg0 == NOT_INTERNALIZED || internalizedArg1 == NOT_INTERNALIZED) {
+            exprStack.add(this)
+
+            if (internalizedArg0 == NOT_INTERNALIZED) {
+                exprStack.add(arg0)
+            }
+            if (internalizedArg1 == NOT_INTERNALIZED) {
+                exprStack.add(arg1)
+            }
+        } else {
+            val internalized = operation(internalizedArg0, internalizedArg1)
+            saveInternalizedExpr(this, internalized)
+        }
+    }
+
+    inline fun <S : KExpr<*>> S.transform(
+        arg0: KExpr<*>,
+        arg1: KExpr<*>,
+        arg2: KExpr<*>,
+        operation: (Long, Long, Long) -> Long
+    ): S = also {
+        val internalizedArg0 = findInternalizedExpr(arg0)
+        val internalizedArg1 = findInternalizedExpr(arg1)
+        val internalizedArg2 = findInternalizedExpr(arg2)
+
+        val someArgumentIsNotInternalzied =
+            internalizedArg0 == NOT_INTERNALIZED
+                    || internalizedArg1 == NOT_INTERNALIZED
+                    || internalizedArg2 == NOT_INTERNALIZED
+
+        if (someArgumentIsNotInternalzied) {
+            exprStack.add(this)
+
+            if (internalizedArg0 == NOT_INTERNALIZED) {
+                exprStack.add(arg0)
+            }
+            if (internalizedArg1 == NOT_INTERNALIZED) {
+                exprStack.add(arg1)
+            }
+            if (internalizedArg2 == NOT_INTERNALIZED) {
+                exprStack.add(arg2)
+            }
+        } else {
+            val internalized = operation(internalizedArg0, internalizedArg1, internalizedArg2)
+            saveInternalizedExpr(this, internalized)
+        }
+    }
+
+    inline fun <S : KExpr<*>> S.transform(
+        arg0: KExpr<*>,
+        arg1: KExpr<*>,
+        arg2: KExpr<*>,
+        arg3: KExpr<*>,
+        operation: (Long, Long, Long, Long) -> Long
+    ): S = also {
+        val internalizedArg0 = findInternalizedExpr(arg0)
+        val internalizedArg1 = findInternalizedExpr(arg1)
+        val internalizedArg2 = findInternalizedExpr(arg2)
+        val internalizedArg3 = findInternalizedExpr(arg3)
+
+        val someArgumentIsNotInternalzied =
+            internalizedArg0 == NOT_INTERNALIZED
+                    || internalizedArg1 == NOT_INTERNALIZED
+                    || internalizedArg2 == NOT_INTERNALIZED
+                    || internalizedArg3 == NOT_INTERNALIZED
+
+        if (someArgumentIsNotInternalzied) {
+            exprStack.add(this)
+
+            if (internalizedArg0 == NOT_INTERNALIZED) {
+                exprStack.add(arg0)
+            }
+            if (internalizedArg1 == NOT_INTERNALIZED) {
+                exprStack.add(arg1)
+            }
+            if (internalizedArg2 == NOT_INTERNALIZED) {
+                exprStack.add(arg2)
+            }
+            if (internalizedArg3 == NOT_INTERNALIZED) {
+                exprStack.add(arg3)
+            }
+        } else {
+
+            val internalized = operation(
+                internalizedArg0,
+                internalizedArg1,
+                internalizedArg2,
+                internalizedArg3
+            )
+            saveInternalizedExpr(this, internalized)
+        }
+    }
+
+    inline fun <S : KExpr<*>> S.transformList(
+        args: List<KExpr<*>>,
+        operation: (LongArray) -> Long
+    ): S = also {
+        val internalizedArgs = LongArray(args.size)
+        var hasNonInternalizedArgs = false
+
+        for (i in args.indices) {
+            val arg = args[i]
+            val internalized = findInternalizedExpr(arg)
+
+            if (internalized != NOT_INTERNALIZED) {
+                internalizedArgs[i] = internalized
+                continue
+            }
+
+            if (!hasNonInternalizedArgs) {
+                hasNonInternalizedArgs = true
+                exprStack.add(this)
+            }
+
+            exprStack.add(arg)
+        }
+
+        if (!hasNonInternalizedArgs) {
+            val internalized = operation(internalizedArgs)
+            saveInternalizedExpr(this, internalized)
+        }
+    }
+
+    companion object {
+        const val NOT_INTERNALIZED = -1L
+    }
+}

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongInternalizerBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongInternalizerBase.kt
@@ -5,7 +5,7 @@ import org.ksmt.expr.transformer.KTransformerBase
 import org.ksmt.sort.KSort
 
 /**
- * Specialized version of [KExprConverterBase] for Long native expressions.
+ * Specialized version of [KExprInternalizerBase] for Long native expressions.
  * */
 abstract class KExprLongInternalizerBase : KTransformerBase {
     @JvmField

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongInternalizerBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongInternalizerBase.kt
@@ -19,97 +19,60 @@ abstract class KExprLongInternalizerBase : KTransformerBase {
 
     abstract fun saveInternalizedExpr(expr: KExpr<*>, internalized: Long)
 
-    fun <S : KSort> KExpr<S>.internalizeExpr(): Long {
-        exprStack.add(this)
+    fun <S : KSort> KExpr<S>.internalizeExpr(): Long = internalizationLoop(
+        exprStack = exprStack,
+        initialExpr = this,
+        notInternalized = NOT_INTERNALIZED,
+        findInternalized = { findInternalizedExpr(it) }
+    )
 
-        while (exprStack.isNotEmpty()) {
-            val expr = exprStack.removeLast()
-
-            val internalized = findInternalizedExpr(expr)
-            if (internalized != NOT_INTERNALIZED) continue
-
-            expr.accept(this@KExprLongInternalizerBase)
-        }
-
-        return findInternalizedExpr(this).also {
-            check(it != NOT_INTERNALIZED) { "expr is not properly internalized: $this" }
-        }
-    }
-
-    inline fun <S : KExpr<*>> S.transform(operation: () -> Long): S = also {
-        saveInternalizedExpr(this, operation())
-    }
+    inline fun <S : KExpr<*>> S.transform(operation: () -> Long): S =
+        transform(
+            operation = { operation() },
+            saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized) }
+        )
 
     inline fun <S : KExpr<*>> S.transform(
         arg: KExpr<*>,
         operation: (Long) -> Long
-    ): S = also {
-        val internalizedArg = findInternalizedExpr(arg)
-
-        if (internalizedArg == NOT_INTERNALIZED) {
-            exprStack.add(this)
-            exprStack.add(arg)
-        } else {
-            val internalized = operation(internalizedArg)
-            saveInternalizedExpr(this, internalized)
-        }
-    }
+    ): S = transform(
+        exprStack = exprStack,
+        arg = arg,
+        operation = { operation(it) },
+        notInternalized = NOT_INTERNALIZED,
+        findInternalized = { findInternalizedExpr(it) },
+        saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized) }
+    )
 
     inline fun <S : KExpr<*>> S.transform(
         arg0: KExpr<*>,
         arg1: KExpr<*>,
         operation: (Long, Long) -> Long
-    ): S = also {
-        val internalizedArg0 = findInternalizedExpr(arg0)
-        val internalizedArg1 = findInternalizedExpr(arg1)
-
-        if (internalizedArg0 == NOT_INTERNALIZED || internalizedArg1 == NOT_INTERNALIZED) {
-            exprStack.add(this)
-
-            if (internalizedArg0 == NOT_INTERNALIZED) {
-                exprStack.add(arg0)
-            }
-            if (internalizedArg1 == NOT_INTERNALIZED) {
-                exprStack.add(arg1)
-            }
-        } else {
-            val internalized = operation(internalizedArg0, internalizedArg1)
-            saveInternalizedExpr(this, internalized)
-        }
-    }
+    ): S = transform(
+        exprStack = exprStack,
+        arg0 = arg0,
+        arg1 = arg1,
+        operation = { a0, a1 -> operation(a0, a1) },
+        notInternalized = NOT_INTERNALIZED,
+        findInternalized = { findInternalizedExpr(it) },
+        saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized) }
+    )
 
     inline fun <S : KExpr<*>> S.transform(
         arg0: KExpr<*>,
         arg1: KExpr<*>,
         arg2: KExpr<*>,
         operation: (Long, Long, Long) -> Long
-    ): S = also {
-        val internalizedArg0 = findInternalizedExpr(arg0)
-        val internalizedArg1 = findInternalizedExpr(arg1)
-        val internalizedArg2 = findInternalizedExpr(arg2)
-
-        val someArgumentIsNotInternalzied =
-            internalizedArg0 == NOT_INTERNALIZED
-                    || internalizedArg1 == NOT_INTERNALIZED
-                    || internalizedArg2 == NOT_INTERNALIZED
-
-        if (someArgumentIsNotInternalzied) {
-            exprStack.add(this)
-
-            if (internalizedArg0 == NOT_INTERNALIZED) {
-                exprStack.add(arg0)
-            }
-            if (internalizedArg1 == NOT_INTERNALIZED) {
-                exprStack.add(arg1)
-            }
-            if (internalizedArg2 == NOT_INTERNALIZED) {
-                exprStack.add(arg2)
-            }
-        } else {
-            val internalized = operation(internalizedArg0, internalizedArg1, internalizedArg2)
-            saveInternalizedExpr(this, internalized)
-        }
-    }
+    ): S = transform(
+        exprStack = exprStack,
+        arg0 = arg0,
+        arg1 = arg1,
+        arg2 = arg2,
+        operation = { a0, a1, a2 -> operation(a0, a1, a2) },
+        notInternalized = NOT_INTERNALIZED,
+        findInternalized = { findInternalizedExpr(it) },
+        saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized) }
+    )
 
     inline fun <S : KExpr<*>> S.transform(
         arg0: KExpr<*>,
@@ -117,74 +80,31 @@ abstract class KExprLongInternalizerBase : KTransformerBase {
         arg2: KExpr<*>,
         arg3: KExpr<*>,
         operation: (Long, Long, Long, Long) -> Long
-    ): S = also {
-        val internalizedArg0 = findInternalizedExpr(arg0)
-        val internalizedArg1 = findInternalizedExpr(arg1)
-        val internalizedArg2 = findInternalizedExpr(arg2)
-        val internalizedArg3 = findInternalizedExpr(arg3)
-
-        val someArgumentIsNotInternalized =
-            internalizedArg0 == NOT_INTERNALIZED
-                    || internalizedArg1 == NOT_INTERNALIZED
-                    || internalizedArg2 == NOT_INTERNALIZED
-                    || internalizedArg3 == NOT_INTERNALIZED
-
-        if (someArgumentIsNotInternalized) {
-            exprStack.add(this)
-
-            if (internalizedArg0 == NOT_INTERNALIZED) {
-                exprStack.add(arg0)
-            }
-            if (internalizedArg1 == NOT_INTERNALIZED) {
-                exprStack.add(arg1)
-            }
-            if (internalizedArg2 == NOT_INTERNALIZED) {
-                exprStack.add(arg2)
-            }
-            if (internalizedArg3 == NOT_INTERNALIZED) {
-                exprStack.add(arg3)
-            }
-        } else {
-
-            val internalized = operation(
-                internalizedArg0,
-                internalizedArg1,
-                internalizedArg2,
-                internalizedArg3
-            )
-            saveInternalizedExpr(this, internalized)
-        }
-    }
+    ): S = transform(
+        exprStack = exprStack,
+        arg0 = arg0,
+        arg1 = arg1,
+        arg2 = arg2,
+        arg3 = arg3,
+        operation = { a0, a1, a2, a3 -> operation(a0, a1, a2, a3) },
+        notInternalized = NOT_INTERNALIZED,
+        findInternalized = { findInternalizedExpr(it) },
+        saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized) }
+    )
 
     inline fun <S : KExpr<*>> S.transformList(
         args: List<KExpr<*>>,
         operation: (LongArray) -> Long
-    ): S = also {
-        val internalizedArgs = LongArray(args.size)
-        var hasNonInternalizedArgs = false
-
-        for (i in args.indices) {
-            val arg = args[i]
-            val internalized = findInternalizedExpr(arg)
-
-            if (internalized != NOT_INTERNALIZED) {
-                internalizedArgs[i] = internalized
-                continue
-            }
-
-            if (!hasNonInternalizedArgs) {
-                hasNonInternalizedArgs = true
-                exprStack.add(this)
-            }
-
-            exprStack.add(arg)
-        }
-
-        if (!hasNonInternalizedArgs) {
-            val internalized = operation(internalizedArgs)
-            saveInternalizedExpr(this, internalized)
-        }
-    }
+    ): S = transformList(
+        exprStack = exprStack,
+        args = args,
+        operation = { transformedArgs -> operation(transformedArgs) },
+        mkArray = { size -> LongArray(size) },
+        setArray = { array, idx, value -> array[idx] = value },
+        notInternalized = NOT_INTERNALIZED,
+        findInternalized = { findInternalizedExpr(it) },
+        saveInternalized = { expr, internalized -> saveInternalizedExpr(expr, internalized) }
+    )
 
     companion object {
         const val NOT_INTERNALIZED = -1L

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongInternalizerBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongInternalizerBase.kt
@@ -123,13 +123,13 @@ abstract class KExprLongInternalizerBase : KTransformerBase {
         val internalizedArg2 = findInternalizedExpr(arg2)
         val internalizedArg3 = findInternalizedExpr(arg3)
 
-        val someArgumentIsNotInternalzied =
+        val someArgumentIsNotInternalized =
             internalizedArg0 == NOT_INTERNALIZED
                     || internalizedArg1 == NOT_INTERNALIZED
                     || internalizedArg2 == NOT_INTERNALIZED
                     || internalizedArg3 == NOT_INTERNALIZED
 
-        if (someArgumentIsNotInternalzied) {
+        if (someArgumentIsNotInternalized) {
             exprStack.add(this)
 
             if (internalizedArg0 == NOT_INTERNALIZED) {

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongInternalizerBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/util/KExprLongInternalizerBase.kt
@@ -4,6 +4,9 @@ import org.ksmt.expr.KExpr
 import org.ksmt.expr.transformer.KTransformerBase
 import org.ksmt.sort.KSort
 
+/**
+ * Specialized version of [KExprConverterBase] for Long native expressions.
+ * */
 abstract class KExprLongInternalizerBase : KTransformerBase {
     @JvmField
     val exprStack = arrayListOf<KExpr<*>>()
@@ -30,8 +33,7 @@ abstract class KExprLongInternalizerBase : KTransformerBase {
     }
 
     inline fun <S : KExpr<*>> S.transform(operation: () -> Long): S = also {
-        val internalized = operation()
-        saveInternalizedExpr(this, internalized)
+        saveInternalizedExpr(this, operation())
     }
 
     inline fun <S : KExpr<*>> S.transform(

--- a/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5ExprConverter.kt
+++ b/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5ExprConverter.kt
@@ -21,6 +21,7 @@ import org.ksmt.expr.KExpr
 import org.ksmt.expr.KFpRoundingMode
 import org.ksmt.solver.KSolverUnsupportedFeatureException
 import org.ksmt.solver.util.KExprConverterBase
+import org.ksmt.solver.util.KExprConverterBase.Companion.ExprConversionResult
 import org.ksmt.sort.KArithSort
 import org.ksmt.sort.KArraySort
 import org.ksmt.sort.KBoolSort

--- a/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5ExprConverter.kt
+++ b/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5ExprConverter.kt
@@ -21,7 +21,8 @@ import org.ksmt.expr.KExpr
 import org.ksmt.expr.KFpRoundingMode
 import org.ksmt.solver.KSolverUnsupportedFeatureException
 import org.ksmt.solver.util.KExprConverterBase
-import org.ksmt.solver.util.KExprConverterBase.Companion.ExprConversionResult
+import org.ksmt.solver.util.ExprConversionResult
+import org.ksmt.solver.util.KExprConverterUtils.argumentsConversionRequired
 import org.ksmt.sort.KArithSort
 import org.ksmt.sort.KArraySort
 import org.ksmt.sort.KBoolSort

--- a/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstSerializer.kt
+++ b/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstSerializer.kt
@@ -249,23 +249,23 @@ class AstSerializer(
             }
         }
 
-        override fun <D0 : KSort, D1 : KSort, R : KSort> visit(sort: KArray2Sort<D0, D1, R>): Int {
+        override fun <D0 : KSort, D1 : KSort, R : KSort> visit(sort: KArray2Sort<D0, D1, R>) {
             val domain0 = sort.domain0.serializeSort()
             val domain1 = sort.domain1.serializeSort()
             val range = sort.range.serializeSort()
-            return serializeSort(sort, SortKind.Array2) {
+            serializeSort(sort, SortKind.Array2) {
                 writeAst(domain0)
                 writeAst(domain1)
                 writeAst(range)
             }
         }
 
-        override fun <D0 : KSort, D1 : KSort, D2 : KSort, R : KSort> visit(sort: KArray3Sort<D0, D1, D2, R>): Int {
+        override fun <D0 : KSort, D1 : KSort, D2 : KSort, R : KSort> visit(sort: KArray3Sort<D0, D1, D2, R>) {
             val domain0 = sort.domain0.serializeSort()
             val domain1 = sort.domain1.serializeSort()
             val domain2 = sort.domain2.serializeSort()
             val range = sort.range.serializeSort()
-            return serializeSort(sort, SortKind.Array3) {
+            serializeSort(sort, SortKind.Array3) {
                 writeAst(domain0)
                 writeAst(domain1)
                 writeAst(domain2)
@@ -273,10 +273,12 @@ class AstSerializer(
             }
         }
 
-        override fun <R : KSort> visit(sort: KArrayNSort<R>): Int {
-            val domain = sort.domainSorts.map { it.serializeSort() }
+        override fun <R : KSort> visit(sort: KArrayNSort<R>) {
+            val domain = sort.domainSorts.let { sorts ->
+                IntArray(sorts.size) { sorts[it].serializeSort() }
+            }
             val range = sort.range.serializeSort()
-            return serializeSort(sort, SortKind.ArrayN) {
+            serializeSort(sort, SortKind.ArrayN) {
                 writeAstArray(domain)
                 writeAst(range)
             }
@@ -904,7 +906,7 @@ class AstSerializer(
     override fun <D0 : KSort, D1 : KSort, D2 : KSort, R : KSort> transform(
         expr: KArray3Store<D0, D1, D2, R>
     ): KExpr<KArray3Sort<D0, D1, D2, R>> = with(expr) {
-        transformList(listOf(array, index0, index1, index2, value)) { args: Array<Int> ->
+        transformList(listOf(array, index0, index1, index2, value)) { args: IntArray ->
             val (a: Int, i0: Int, i1: Int, i2: Int, v: Int) = args
             writeExpr {
                 writeAst(a)
@@ -917,10 +919,10 @@ class AstSerializer(
     }
 
     override fun <R : KSort> transform(expr: KArrayNStore<R>): KExpr<KArrayNSort<R>> = with(expr) {
-        transformList(indices + listOf(array, value)) { args: Array<Int> ->
+        transformList(indices + listOf(array, value)) { args: IntArray ->
             val array = args[args.lastIndex - 1]
             val value = args[args.lastIndex]
-            val indices = args.dropLast(2)
+            val indices = args.copyOf(args.size - 2)
             writeExpr {
                 writeAst(array)
                 writeAstArray(indices)
@@ -953,9 +955,9 @@ class AstSerializer(
     }
 
     override fun <R : KSort> transform(expr: KArrayNSelect<R>): KExpr<R> = with(expr) {
-        transformList(indices + array) { args: Array<Int> ->
+        transformList(indices + array) { args: IntArray ->
             val array = args.last()
-            val indices = args.dropLast(1)
+            val indices = args.copyOf(args.size - 1)
             writeExpr {
                 writeAst(array)
                 writeAstArray(indices)

--- a/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstSerializer.kt
+++ b/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstSerializer.kt
@@ -144,7 +144,7 @@ import org.ksmt.expr.KTrue
 import org.ksmt.expr.KUnaryMinusArithExpr
 import org.ksmt.expr.KUniversalQuantifier
 import org.ksmt.expr.KXorExpr
-import org.ksmt.solver.util.KExprInternalizerBase
+import org.ksmt.solver.util.KExprIntInternalizerBase
 import org.ksmt.sort.KArithSort
 import org.ksmt.sort.KArray2Sort
 import org.ksmt.sort.KArray3Sort
@@ -165,12 +165,12 @@ import org.ksmt.sort.KSort
 import org.ksmt.sort.KSortVisitor
 import org.ksmt.sort.KUninterpretedSort
 
-@Suppress("ArrayPrimitive", "LargeClass")
+@Suppress("LargeClass")
 @OptIn(ExperimentalUnsignedTypes::class)
 class AstSerializer(
     private val serializationCtx: AstSerializationCtx,
     private val output: AbstractBuffer
-) : KExprInternalizerBase<Int>() {
+) : KExprIntInternalizerBase() {
 
     private val exprKindMapper = ExprKindMapper()
 
@@ -201,7 +201,8 @@ class AstSerializer(
         return accept(sortSerializer)
     }
 
-    override fun findInternalizedExpr(expr: KExpr<*>): Int? = serializationCtx.getAstIndex(expr)
+    override fun findInternalizedExpr(expr: KExpr<*>): Int =
+        serializationCtx.getAstIndex(expr) ?: NOT_INTERNALIZED
 
     override fun saveInternalizedExpr(expr: KExpr<*>, internalized: Int) {
         // Do nothing since expr is already saved into serializationCtx
@@ -305,9 +306,8 @@ class AstSerializer(
         writeIntArray(indices)
     }
 
-    private fun AbstractBuffer.writeAstArray(asts: Array<Int>) {
-        val indices = asts.toIntArray()
-        writeIntArray(indices)
+    private fun AbstractBuffer.writeAstArray(asts: IntArray) {
+        writeIntArray(asts)
     }
 
     private inline fun KAst.serializeAst(body: AbstractBuffer.() -> Unit): Int {
@@ -358,7 +358,7 @@ class AstSerializer(
     }
 
     override fun <T : KSort> transform(expr: KFunctionApp<T>) = with(expr) {
-        transformList(args) { args: Array<Int> ->
+        transformList(args) { args: IntArray ->
             val declIdx = decl.serializeDecl()
             writeExpr {
                 writeAst(declIdx)
@@ -377,7 +377,7 @@ class AstSerializer(
     }
 
     override fun transform(expr: KAndExpr) = with(expr) {
-        transformList(args) { args: Array<Int> ->
+        transformList(args) { args: IntArray ->
             writeExpr {
                 writeAstArray(args)
             }
@@ -385,7 +385,7 @@ class AstSerializer(
     }
 
     override fun transform(expr: KOrExpr) = with(expr) {
-        transformList(args) { args: Array<Int> ->
+        transformList(args) { args: IntArray ->
             writeExpr {
                 writeAstArray(args)
             }
@@ -405,7 +405,7 @@ class AstSerializer(
     override fun <T : KSort> transform(expr: KEqExpr<T>) = with(expr) { serialize(lhs, rhs) }
 
     override fun <T : KSort> transform(expr: KDistinctExpr<T>) = with(expr) {
-        transformList(args) { args: Array<Int> ->
+        transformList(args) { args: IntArray ->
             writeExpr {
                 writeAstArray(args)
             }
@@ -992,7 +992,7 @@ class AstSerializer(
     }
 
     override fun <T : KArithSort> transform(expr: KAddArithExpr<T>) = with(expr) {
-        transformList(args) { args: Array<Int> ->
+        transformList(args) { args: IntArray ->
             writeExpr {
                 writeAstArray(args)
             }
@@ -1000,7 +1000,7 @@ class AstSerializer(
     }
 
     override fun <T : KArithSort> transform(expr: KSubArithExpr<T>) = with(expr) {
-        transformList(args) { args: Array<Int> ->
+        transformList(args) { args: IntArray ->
             writeExpr {
                 writeAstArray(args)
             }
@@ -1008,7 +1008,7 @@ class AstSerializer(
     }
 
     override fun <T : KArithSort> transform(expr: KMulArithExpr<T>) = with(expr) {
-        transformList(args) { args: Array<Int> ->
+        transformList(args) { args: IntArray ->
             writeExpr {
                 writeAstArray(args)
             }

--- a/ksmt-test/src/main/kotlin/org/ksmt/test/TestWorkerProcess.kt
+++ b/ksmt-test/src/main/kotlin/org/ksmt/test/TestWorkerProcess.kt
@@ -216,7 +216,8 @@ class TestWorkerProcess : ChildProcessBase<TestProtocolModel>() {
 
     private fun internalize(expr: KExpr<*>): Expr<*> {
         val internalizer = KZ3ExprInternalizer(ctx, KZ3Context(z3Ctx))
-        return with(internalizer) { expr.internalizeExprWrapped() }
+        val internalized = with(internalizer) { expr.internalizeExpr() }
+        return z3Ctx.wrapAST(internalized) as Expr<*>
     }
 
     private data class EqualityCheck(val actual: Expr<*>, val expected: Expr<*>)

--- a/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesExprConverter.kt
+++ b/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesExprConverter.kt
@@ -9,6 +9,7 @@ import org.ksmt.expr.KExpr
 import org.ksmt.solver.util.KExprConverterBase
 import org.ksmt.decl.KDecl
 import org.ksmt.decl.KFuncDecl
+import org.ksmt.solver.util.KExprConverterBase.Companion.ExprConversionResult
 import org.ksmt.sort.KArithSort
 import org.ksmt.sort.KArraySort
 import org.ksmt.sort.KBoolSort

--- a/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesExprConverter.kt
+++ b/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesExprConverter.kt
@@ -9,7 +9,7 @@ import org.ksmt.expr.KExpr
 import org.ksmt.solver.util.KExprConverterBase
 import org.ksmt.decl.KDecl
 import org.ksmt.decl.KFuncDecl
-import org.ksmt.solver.util.KExprConverterBase.Companion.ExprConversionResult
+import org.ksmt.solver.util.ExprConversionResult
 import org.ksmt.sort.KArithSort
 import org.ksmt.sort.KArraySort
 import org.ksmt.sort.KBoolSort

--- a/ksmt-z3/src/main/kotlin/com/microsoft/z3/Util.kt
+++ b/ksmt-z3/src/main/kotlin/com/microsoft/z3/Util.kt
@@ -1,33 +1,36 @@
 package com.microsoft.z3
 
+import com.microsoft.z3.Native.IntPtr
+import com.microsoft.z3.Native.LongPtr
 import com.microsoft.z3.enumerations.Z3_error_code
+import com.microsoft.z3.enumerations.Z3_lbool
 
 fun intOrNull(ctx: Long, expr: Long): Int? {
-    val result = Native.IntPtr()
+    val result = IntPtr()
     if (!Native.getNumeralInt(ctx, expr, result)) return null
     return result.value
 }
 
 fun longOrNull(ctx: Long, expr: Long): Long? {
-    val result = Native.LongPtr()
+    val result = LongPtr()
     if (!Native.getNumeralInt64(ctx, expr, result)) return null
     return result.value
 }
 
 fun fpSignificandUInt64OrNull(ctx: Long, expr: Long): Long? {
-    val result = Native.LongPtr()
+    val result = LongPtr()
     if (!Native.fpaGetNumeralSignificandUint64(ctx, expr, result)) return null
     return result.value
 }
 
 fun fpExponentInt64OrNull(ctx: Long, expr: Long, biased: Boolean): Long? {
-    val result = Native.LongPtr()
+    val result = LongPtr()
     if (!Native.fpaGetNumeralExponentInt64(ctx, expr, result, biased)) return null
     return result.value
 }
 
 fun fpSignOrNull(ctx: Long, expr: Long): Boolean? {
-    val result = Native.IntPtr()
+    val result = IntPtr()
     if (!Native.fpaGetNumeralSign(ctx, expr, result)) return null
     return result.value != 0
 }
@@ -72,4 +75,113 @@ fun getArraySortDomain(ctx: Long, sort: Long): List<Long> {
         }
     }
     return domain
+}
+
+fun Solver.solverAssert(expr: Long) {
+    Native.solverAssert(context.nCtx(), nativeObject, expr)
+}
+
+fun Solver.solverAssertAndTrack(expr: Long, track: Long) {
+    Native.solverAssertAndTrack(context.nCtx(), nativeObject, expr, track)
+}
+
+fun Solver.solverCheckAssumptions(assumptions: LongArray): Status {
+    val checkResult = Native.solverCheckAssumptions(context.nCtx(), nativeObject, assumptions.size, assumptions)
+    return when (Z3_lbool.fromInt(checkResult)) {
+        Z3_lbool.Z3_L_TRUE -> Status.SATISFIABLE
+        Z3_lbool.Z3_L_FALSE -> Status.UNSATISFIABLE
+        else -> Status.UNKNOWN
+    }
+}
+
+private fun astVectorToLongArray(ctx: Long, vector: Long): LongArray {
+    Native.astVectorIncRef(ctx, vector)
+    return try {
+        val size = Native.astVectorSize(ctx, vector)
+        LongArray(size) {
+            Native.astVectorGet(ctx, vector, it)
+        }
+    } finally {
+        Native.astVectorDecRef(ctx, vector)
+    }
+}
+
+fun Solver.solverGetUnsatCore(): LongArray {
+    val nativeUnsatCoreVector = Native.solverGetUnsatCore(context.nCtx(), nativeObject)
+    return astVectorToLongArray(context.nCtx(), nativeUnsatCoreVector)
+}
+
+fun Model.getNativeConstDecls(): LongArray = LongArray(numConsts) {
+    Native.modelGetConstDecl(context.nCtx(), nativeObject, it)
+}
+
+fun Model.getNativeFuncDecls(): LongArray = LongArray(numFuncs) {
+    Native.modelGetFuncDecl(context.nCtx(), nativeObject, it)
+}
+
+fun Model.getNativeSorts(): LongArray = LongArray(numSorts) {
+    Native.modelGetSort(context.nCtx(), nativeObject, it)
+}
+
+fun Model.getSortUniverse(sort: Long): LongArray {
+    val nativeSortUniverseVector = Native.modelGetSortUniverse(context.nCtx(), nativeObject, sort)
+    return astVectorToLongArray(context.nCtx(), nativeSortUniverseVector)
+}
+
+fun Model.evalNative(expr: Long, complete: Boolean): Long {
+    val result = LongPtr()
+    if (!Native.modelEval(context.nCtx(), nativeObject, expr, complete, result)) {
+        throw ModelEvaluationFailedException()
+    }
+    return result.value
+}
+
+fun Model.getConstInterp(decl: Long): Long? {
+    val interp = Native.modelGetConstInterp(context.nCtx(), nativeObject, decl)
+    return interp.takeIf { it != 0L }
+}
+
+fun Model.getFuncInterp(decl: Long): Z3NativeFuncInterp? {
+    val interp = Native.modelGetFuncInterp(context.nCtx(), nativeObject, decl)
+    if (interp == 0L) return null
+    return retrieveNativeFuncInterp(context.nCtx(), interp)
+}
+
+class Z3NativeFuncInterpEntry(
+    val args: LongArray,
+    val value: Long
+)
+
+class Z3NativeFuncInterp(
+    val entries: Array<Z3NativeFuncInterpEntry>,
+    val elseExpr: Long
+)
+
+private fun retrieveNativeFuncInterp(ctx: Long, nativeFuncInterp: Long): Z3NativeFuncInterp {
+    Native.funcInterpIncRef(ctx, nativeFuncInterp)
+    return try {
+        val numEntries = Native.funcInterpGetNumEntries(ctx, nativeFuncInterp)
+        val entries = Array(numEntries) {
+            val nativeEntry = Native.funcInterpGetEntry(ctx, nativeFuncInterp, it)
+            retrieveNativeFuncInterpEntry(ctx, nativeEntry)
+        }
+        val elseExpr = Native.funcInterpGetElse(ctx, nativeFuncInterp)
+        Z3NativeFuncInterp(entries, elseExpr)
+    } finally {
+        Native.funcInterpDecRef(ctx, nativeFuncInterp)
+    }
+}
+
+private fun retrieveNativeFuncInterpEntry(ctx: Long, nativeEntry: Long): Z3NativeFuncInterpEntry {
+    Native.funcEntryIncRef(ctx, nativeEntry)
+    return try {
+        val argsSize = Native.funcEntryGetNumArgs(ctx, nativeEntry)
+        val args = LongArray(argsSize) {
+            Native.funcEntryGetArg(ctx, nativeEntry, it)
+        }
+        val value = Native.funcEntryGetValue(ctx, nativeEntry)
+        Z3NativeFuncInterpEntry(args, value)
+    } finally {
+        Native.funcEntryDecRef(ctx, nativeEntry)
+    }
 }

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Context.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Context.kt
@@ -146,9 +146,14 @@ class KZ3Context(private val ctx: Context) : AutoCloseable {
         cache: Object2LongOpenHashMap<T>,
         reverseCache: Long2ObjectOpenHashMap<T>
     ): T {
-        val reverseCached = reverseCache.get(native)
+        val reverseCached = reverseCache.putIfAbsent(native, ksmt)
         if (reverseCached != null) return reverseCached
-        saveAst(native, ksmt, cache, reverseCache)
+
+        val cached = cache.putIfAbsent(ksmt, native)
+        if (cached == NOT_INTERNALIZED) {
+            incRefUnsafe(nCtx, native)
+        }
+
         return ksmt
     }
 

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Context.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Context.kt
@@ -149,10 +149,8 @@ class KZ3Context(private val ctx: Context) : AutoCloseable {
         val reverseCached = reverseCache.putIfAbsent(native, ksmt)
         if (reverseCached != null) return reverseCached
 
-        val cached = cache.putIfAbsent(ksmt, native)
-        if (cached == NOT_INTERNALIZED) {
-            incRefUnsafe(nCtx, native)
-        }
+        cache.putIfAbsent(ksmt, native)
+        incRefUnsafe(nCtx, native)
 
         return ksmt
     }

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3DeclInternalizer.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3DeclInternalizer.kt
@@ -1,6 +1,7 @@
 package org.ksmt.solver.z3
 
 import com.microsoft.z3.Native
+import org.ksmt.decl.KConstDecl
 import org.ksmt.decl.KDecl
 import org.ksmt.decl.KDeclVisitor
 import org.ksmt.decl.KFuncDecl
@@ -28,6 +29,19 @@ open class KZ3DeclInternalizer(
             domainSorts.size,
             domainSorts,
             rangeSort
+        )
+    }
+
+    override fun <S : KSort> visit(decl: KConstDecl<S>) {
+        val declSort = sortInternalizer.internalizeZ3Sort(decl.sort)
+        val nameSymbol = Native.mkStringSymbol(nCtx, decl.name)
+
+        lastInternalizedDecl = Native.mkFuncDecl(
+            nCtx,
+            nameSymbol,
+            0,
+            null,
+            declSort
         )
     }
 

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3DeclInternalizer.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3DeclInternalizer.kt
@@ -1,26 +1,38 @@
 package org.ksmt.solver.z3
 
 import com.microsoft.z3.Native
+import org.ksmt.decl.KDecl
 import org.ksmt.decl.KDeclVisitor
 import org.ksmt.decl.KFuncDecl
+import org.ksmt.solver.util.KExprLongInternalizerBase.Companion.NOT_INTERNALIZED
 import org.ksmt.sort.KSort
 
 open class KZ3DeclInternalizer(
     private val z3Ctx: KZ3Context,
     private val sortInternalizer: KZ3SortInternalizer
-) : KDeclVisitor<Long> {
-    override fun <S : KSort> visit(
-        decl: KFuncDecl<S>
-    ): Long = z3Ctx.internalizeDecl(decl) {
-        val domainSorts = decl.argSorts.map { it.accept(sortInternalizer) }
-        val rangeSort = decl.sort.accept(sortInternalizer)
-        val nameSymbol = Native.mkStringSymbol(z3Ctx.nCtx, decl.name)
-        Native.mkFuncDecl(
-            z3Ctx.nCtx,
+) : KDeclVisitor<Unit> {
+    private val nCtx = z3Ctx.nCtx
+    private var lastInternalizedDecl: Long = NOT_INTERNALIZED
+
+    override fun <S : KSort> visit(decl: KFuncDecl<S>) {
+        val domainSorts = decl.argSorts.let { argSorts ->
+            LongArray(argSorts.size) { sortInternalizer.internalizeZ3Sort(argSorts[it]) }
+        }
+
+        val rangeSort = sortInternalizer.internalizeZ3Sort(decl.sort)
+        val nameSymbol = Native.mkStringSymbol(nCtx, decl.name)
+
+        lastInternalizedDecl = Native.mkFuncDecl(
+            nCtx,
             nameSymbol,
             domainSorts.size,
-            domainSorts.toLongArray(),
+            domainSorts,
             rangeSort
         )
+    }
+
+    fun internalizeZ3Decl(decl: KDecl<*>): Long = z3Ctx.internalizeDecl(decl) {
+        decl.accept(this@KZ3DeclInternalizer)
+        lastInternalizedDecl
     }
 }

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprConverter.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprConverter.kt
@@ -19,8 +19,8 @@ import org.ksmt.expr.KFpRoundingMode
 import org.ksmt.expr.KFpRoundingModeExpr
 import org.ksmt.expr.KIntNumExpr
 import org.ksmt.expr.KRealNumExpr
-import org.ksmt.solver.util.KExprConverterBase.Companion.ExprConversionResult
-import org.ksmt.solver.util.KExprConverterBase.Companion.argumentsConversionRequired
+import org.ksmt.solver.util.ExprConversionResult
+import org.ksmt.solver.util.KExprConverterUtils.argumentsConversionRequired
 import org.ksmt.solver.util.KExprLongConverterBase
 import org.ksmt.sort.KArithSort
 import org.ksmt.sort.KArray2Sort

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprConverter.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprConverter.kt
@@ -1,9 +1,6 @@
 package org.ksmt.solver.z3
 
-import com.microsoft.z3.Expr
-import com.microsoft.z3.FuncDecl
 import com.microsoft.z3.Native
-import com.microsoft.z3.Sort
 import com.microsoft.z3.enumerations.Z3_ast_kind
 import com.microsoft.z3.enumerations.Z3_decl_kind
 import com.microsoft.z3.enumerations.Z3_sort_kind
@@ -57,15 +54,6 @@ open class KZ3ExprConverter(
     override fun saveConvertedNative(native: Long, converted: KExpr<*>) {
         z3Ctx.saveConvertedExpr(native, converted)
     }
-
-    fun <T : KSort> Expr<*>.convertExprWrapped(): KExpr<T> =
-        z3Ctx.nativeContext.unwrapAST(this).convertExpr()
-
-    fun <T : KSort> FuncDecl<*>.convertDeclWrapped(): KDecl<T> =
-        z3Ctx.nativeContext.unwrapAST(this).convertDecl()
-
-    fun Sort.convertSortWrapped(): KSort =
-        z3Ctx.nativeContext.unwrapAST(this).convertSort()
 
     fun <T : KSort> Long.convertExpr(): KExpr<T> = convertFromNative(this)
 
@@ -299,7 +287,7 @@ open class KZ3ExprConverter(
             Z3_decl_kind.Z3_OP_BSMUL_NO_UDFL -> expr.convert(::mkBvMulNoUnderflowExpr)
             Z3_decl_kind.Z3_OP_AS_ARRAY -> convert {
                 val sort = Native.getRange(nCtx, decl).convertSort<KArraySortBase<KSort>>()
-                val z3Decl = Native.getDeclFuncDeclParameter(nCtx, decl, 0).convertDecl<KSort>()
+                val z3Decl = Native.getAsArrayFuncDecl(nCtx, expr).convertDecl<KSort>()
                 val funDecl = z3Decl as? KFuncDecl<KSort> ?: error("unexpected as-array decl $z3Decl")
                 mkFunctionAsArray(sort, funDecl)
             }

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
@@ -149,7 +149,7 @@ import org.ksmt.expr.KTrue
 import org.ksmt.expr.KUnaryMinusArithExpr
 import org.ksmt.expr.KUniversalQuantifier
 import org.ksmt.expr.KXorExpr
-import org.ksmt.solver.util.KExprInternalizerBase
+import org.ksmt.solver.util.KExprLongInternalizerBase
 import org.ksmt.sort.KArithSort
 import org.ksmt.sort.KArray2Sort
 import org.ksmt.sort.KArray3Sort
@@ -167,18 +167,19 @@ import org.ksmt.sort.KFpSort
 import org.ksmt.sort.KRealSort
 import org.ksmt.sort.KSort
 
-@Suppress("SpreadOperator")
 open class KZ3ExprInternalizer(
     val ctx: KContext,
     private val z3InternCtx: KZ3Context
-) : KExprInternalizerBase<Long>() {
+) : KExprLongInternalizerBase() {
 
+    @JvmField
     val nCtx: Long = z3InternCtx.nCtx
 
     private val sortInternalizer = KZ3SortInternalizer(z3InternCtx)
     private val declInternalizer = KZ3DeclInternalizer(z3InternCtx, sortInternalizer)
 
-    override fun findInternalizedExpr(expr: KExpr<*>): Long? = z3InternCtx.findInternalizedExpr(expr)
+    override fun findInternalizedExpr(expr: KExpr<*>): Long =
+        z3InternCtx.findInternalizedExpr(expr) ?: NOT_INTERNALIZED
 
     override fun saveInternalizedExpr(expr: KExpr<*>, internalized: Long) {
         z3InternCtx.saveInternalizedExpr(expr, internalized)
@@ -851,10 +852,9 @@ open class KZ3ExprInternalizer(
         operation(nCtx, a0, a1, a2, a3)
     }
 
-    @Suppress("ArrayPrimitive")
     inline fun <S : KExpr<*>> S.transformArray(
         args: List<KExpr<*>>,
         operation: (LongArray) -> Long
-    ): S = transformList(args) { a: Array<Long> -> operation(a.toLongArray()) }
+    ): S = transformList(args) { a: LongArray -> operation(a) }
 
 }

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
@@ -179,7 +179,7 @@ open class KZ3ExprInternalizer(
     private val declInternalizer = KZ3DeclInternalizer(z3InternCtx, sortInternalizer)
 
     override fun findInternalizedExpr(expr: KExpr<*>): Long =
-        z3InternCtx.findInternalizedExpr(expr) ?: NOT_INTERNALIZED
+        z3InternCtx.findInternalizedExpr(expr)
 
     override fun saveInternalizedExpr(expr: KExpr<*>, internalized: Long) {
         z3InternCtx.saveInternalizedExpr(expr, internalized)
@@ -194,9 +194,9 @@ open class KZ3ExprInternalizer(
     fun KSort.internalizeSortWrapped(): Sort =
         z3InternCtx.nativeContext.wrapAST(internalizeSort()) as Sort
 
-    fun <T : KDecl<*>> T.internalizeDecl(): Long = accept(declInternalizer)
+    fun <T : KDecl<*>> T.internalizeDecl(): Long = declInternalizer.internalizeZ3Decl(this)
 
-    fun <T : KSort> T.internalizeSort(): Long = accept(sortInternalizer)
+    fun <T : KSort> T.internalizeSort(): Long = sortInternalizer.internalizeZ3Sort(this)
 
     override fun <T : KSort> transform(expr: KFunctionApp<T>) = with(expr) {
         transformArray(args) { args ->

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
@@ -675,7 +675,9 @@ open class KZ3ExprInternalizer(
         if (sort is KArraySort<*, *>) {
             Native.mkConstArray(nCtx, sort.domain.internalizeSort(), value)
         } else {
-            val domain = sort.domainSorts.map { it.internalizeSort() }.toLongArray()
+            val domain = sort.domainSorts.let { domain ->
+                LongArray(domain.size) { domain[it].internalizeSort() }
+            }
             val domainNames = LongArray(sort.domainSorts.size) { Native.mkIntSymbol(nCtx, it) }
             Native.mkLambda(nCtx, domain.size, domain, domainNames, value)
         }

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
@@ -1,9 +1,6 @@
 package org.ksmt.solver.z3
 
-import com.microsoft.z3.Expr
-import com.microsoft.z3.FuncDecl
 import com.microsoft.z3.Native
-import com.microsoft.z3.Sort
 import com.microsoft.z3.mkQuantifier
 import org.ksmt.KContext
 import org.ksmt.decl.KDecl
@@ -184,15 +181,6 @@ open class KZ3ExprInternalizer(
     override fun saveInternalizedExpr(expr: KExpr<*>, internalized: Long) {
         z3InternCtx.saveInternalizedExpr(expr, internalized)
     }
-
-    fun <T : KSort> KExpr<T>.internalizeExprWrapped(): Expr<*> =
-        z3InternCtx.nativeContext.wrapAST(internalizeExpr()) as Expr<*>
-
-    fun <T : KDecl<*>> T.internalizeDeclWrapped(): FuncDecl<*> =
-        z3InternCtx.nativeContext.wrapAST(internalizeDecl()) as FuncDecl<*>
-
-    fun KSort.internalizeSortWrapped(): Sort =
-        z3InternCtx.nativeContext.wrapAST(internalizeSort()) as Sort
 
     fun <T : KDecl<*>> T.internalizeDecl(): Long = declInternalizer.internalizeZ3Decl(this)
 

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3SMTLibParser.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3SMTLibParser.kt
@@ -42,7 +42,7 @@ class KZ3SMTLibParser(private val ctx: KContext) : KSMTLibParser {
 
     private fun KZ3Context.convertAssertions(assertions: List<BoolExpr>): List<KExpr<KBoolSort>> {
         val converter = KZ3ExprConverter(ctx, this)
-        return with(converter) { assertions.map { it.convertExprWrapped() } }
+        return with(converter) { assertions.map { nativeContext.unwrapAST(it).convertExpr() } }
     }
 
     companion object {

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Solver.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Solver.kt
@@ -1,9 +1,12 @@
 package org.ksmt.solver.z3
 
-import com.microsoft.z3.BoolExpr
 import com.microsoft.z3.Solver
 import com.microsoft.z3.Status
 import com.microsoft.z3.Z3Exception
+import com.microsoft.z3.solverAssert
+import com.microsoft.z3.solverAssertAndTrack
+import com.microsoft.z3.solverCheckAssumptions
+import com.microsoft.z3.solverGetUnsatCore
 import org.ksmt.KContext
 import org.ksmt.decl.KConstDecl
 import org.ksmt.expr.KExpr
@@ -64,17 +67,17 @@ open class KZ3Solver(private val ctx: KContext) : KSolver<KZ3SolverConfiguration
     override fun assert(expr: KExpr<KBoolSort>) = z3Try {
         ctx.ensureContextMatch(expr)
 
-        val z3Expr = with(exprInternalizer) { expr.internalizeExprWrapped() }
-        solver.add(z3Expr as BoolExpr)
+        val z3Expr = with(exprInternalizer) { expr.internalizeExpr() }
+        solver.solverAssert(z3Expr)
     }
 
     override fun assertAndTrack(expr: KExpr<KBoolSort>, trackVar: KConstDecl<KBoolSort>) = z3Try {
         ctx.ensureContextMatch(expr, trackVar)
 
-        val z3Expr = with(exprInternalizer) { expr.internalizeExprWrapped() } as BoolExpr
-        val z3TrackVar = with(exprInternalizer) { trackVar.apply().internalizeExprWrapped() } as BoolExpr
+        val z3Expr = with(exprInternalizer) { expr.internalizeExpr() }
+        val z3TrackVar = with(exprInternalizer) { trackVar.apply().internalizeExpr() }
 
-        solver.assertAndTrack(z3Expr, z3TrackVar)
+        solver.solverAssertAndTrack(z3Expr, z3TrackVar)
     }
 
     override fun check(timeout: Duration): KSolverStatus = z3Try {
@@ -82,16 +85,19 @@ open class KZ3Solver(private val ctx: KContext) : KSolver<KZ3SolverConfiguration
         solver.check().processCheckResult()
     }
 
-    @Suppress("SpreadOperator")
     override fun checkWithAssumptions(
         assumptions: List<KExpr<KBoolSort>>,
         timeout: Duration
     ): KSolverStatus = z3Try {
         ctx.ensureContextMatch(assumptions)
 
-        val z3Assumptions = with(exprInternalizer) { assumptions.map { it.internalizeExprWrapped() as BoolExpr } }
+        val z3Assumptions = with(exprInternalizer) {
+            LongArray(assumptions.size) { assumptions[it].internalizeExpr() }
+        }
+
         solver.updateTimeout(timeout)
-        solver.check(*z3Assumptions.toTypedArray()).processCheckResult()
+
+        solver.solverCheckAssumptions(z3Assumptions).processCheckResult()
     }
 
     override fun model(): KModel = z3Try {
@@ -106,8 +112,12 @@ open class KZ3Solver(private val ctx: KContext) : KSolver<KZ3SolverConfiguration
     // TODO add mapping back from tracked variable into initial value
     override fun unsatCore(): List<KExpr<KBoolSort>> = z3Try {
         require(lastCheckStatus == KSolverStatus.UNSAT) { "Unsat cores are only available after UNSAT checks" }
-        val z3Core = solver.unsatCore
-        with(exprConverter) { z3Core.map { it.convertExprWrapped() } }
+
+        val unsatCore = solver.solverGetUnsatCore()
+
+        with(exprConverter) {
+            unsatCore.map { it.convertExpr() }
+        }
     }
 
     override fun reasonOfUnknown(): String = z3Try {

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3SortInternalizer.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3SortInternalizer.kt
@@ -46,33 +46,32 @@ open class KZ3SortInternalizer(
         internalizedSort = Native.mkArraySort(nCtx, domain, range)
     }
 
-    override fun <D0 : KSort, D1 : KSort, R : KSort> visit(sort: KArray2Sort<D0, D1, R>): Long =
-        z3Ctx.internalizeSort(sort) {
-            val domain = longArrayOf(
-                sort.domain0.internalizeZ3Sort(),
-                sort.domain1.internalizeZ3Sort()
-            )
-            val range = sort.range.internalizeZ3Sort()
-            Native.mkArraySortN(nCtx, domain.size, domain, range)
-        }
+    override fun <D0 : KSort, D1 : KSort, R : KSort> visit(sort: KArray2Sort<D0, D1, R>) {
+        val domain = longArrayOf(
+            internalizeZ3Sort(sort.domain0),
+            internalizeZ3Sort(sort.domain1)
+        )
+        val range = internalizeZ3Sort(sort.range)
+        internalizedSort = Native.mkArraySortN(nCtx, domain.size, domain, range)
+    }
 
-    override fun <D0 : KSort, D1 : KSort, D2 : KSort, R : KSort> visit(sort: KArray3Sort<D0, D1, D2, R>): Long =
-        z3Ctx.internalizeSort(sort) {
-            val domain = longArrayOf(
-                sort.domain0.internalizeZ3Sort(),
-                sort.domain1.internalizeZ3Sort(),
-                sort.domain2.internalizeZ3Sort()
-            )
-            val range = sort.range.internalizeZ3Sort()
-            Native.mkArraySortN(nCtx, domain.size, domain, range)
-        }
+    override fun <D0 : KSort, D1 : KSort, D2 : KSort, R : KSort> visit(sort: KArray3Sort<D0, D1, D2, R>) {
+        val domain = longArrayOf(
+            internalizeZ3Sort(sort.domain0),
+            internalizeZ3Sort(sort.domain1),
+            internalizeZ3Sort(sort.domain2)
+        )
+        val range = internalizeZ3Sort(sort.range)
+        internalizedSort = Native.mkArraySortN(nCtx, domain.size, domain, range)
+    }
 
-    override fun <R : KSort> visit(sort: KArrayNSort<R>): Long =
-        z3Ctx.internalizeSort(sort) {
-            val domain = sort.domainSorts.map { it.internalizeZ3Sort() }.toLongArray()
-            val range = sort.range.internalizeZ3Sort()
-            Native.mkArraySortN(nCtx, domain.size, domain, range)
+    override fun <R : KSort> visit(sort: KArrayNSort<R>) {
+        val domain = sort.domainSorts.let { sorts ->
+            LongArray(sorts.size) { internalizeZ3Sort(sorts[it]) }
         }
+        val range = internalizeZ3Sort(sort.range)
+        internalizedSort = Native.mkArraySortN(nCtx, domain.size, domain, range)
+    }
 
     override fun visit(sort: KFpRoundingModeSort) {
         internalizedSort = Native.mkFpaRoundingModeSort(nCtx)

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3SortInternalizer.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3SortInternalizer.kt
@@ -1,6 +1,7 @@
 package org.ksmt.solver.z3
 
 import com.microsoft.z3.Native
+import org.ksmt.solver.util.KExprLongInternalizerBase.Companion.NOT_INTERNALIZED
 import org.ksmt.sort.KArray2Sort
 import org.ksmt.sort.KArray3Sort
 import org.ksmt.sort.KArrayNSort
@@ -23,27 +24,27 @@ import org.ksmt.sort.KUninterpretedSort
 
 open class KZ3SortInternalizer(
     private val z3Ctx: KZ3Context
-) : KSortVisitor<Long> {
+) : KSortVisitor<Unit> {
+    private var internalizedSort: Long = NOT_INTERNALIZED
     private val nCtx: Long = z3Ctx.nCtx
 
-    override fun visit(sort: KBoolSort): Long = z3Ctx.internalizeSort(sort) {
-        Native.mkBoolSort(nCtx)
+    override fun visit(sort: KBoolSort) {
+        internalizedSort = Native.mkBoolSort(nCtx)
     }
 
-    override fun visit(sort: KIntSort): Long = z3Ctx.internalizeSort(sort) {
-        Native.mkIntSort(nCtx)
+    override fun visit(sort: KIntSort) {
+        internalizedSort = Native.mkIntSort(nCtx)
     }
 
-    override fun visit(sort: KRealSort): Long = z3Ctx.internalizeSort(sort) {
-        Native.mkRealSort(nCtx)
+    override fun visit(sort: KRealSort) {
+        internalizedSort = Native.mkRealSort(nCtx)
     }
 
-    override fun <D : KSort, R : KSort> visit(sort: KArraySort<D, R>): Long =
-        z3Ctx.internalizeSort(sort) {
-            val domain = sort.domain.internalizeZ3Sort()
-            val range = sort.range.internalizeZ3Sort()
-            Native.mkArraySort(nCtx, domain, range)
-        }
+    override fun <D : KSort, R : KSort> visit(sort: KArraySort<D, R>) {
+        val domain = internalizeZ3Sort(sort.domain)
+        val range = internalizeZ3Sort(sort.range)
+        internalizedSort = Native.mkArraySort(nCtx, domain, range)
+    }
 
     override fun <D0 : KSort, D1 : KSort, R : KSort> visit(sort: KArray2Sort<D0, D1, R>): Long =
         z3Ctx.internalizeSort(sort) {
@@ -73,17 +74,17 @@ open class KZ3SortInternalizer(
             Native.mkArraySortN(nCtx, domain.size, domain, range)
         }
 
-    override fun visit(sort: KFpRoundingModeSort): Long = z3Ctx.internalizeSort(sort) {
-        Native.mkFpaRoundingModeSort(nCtx)
+    override fun visit(sort: KFpRoundingModeSort) {
+        internalizedSort = Native.mkFpaRoundingModeSort(nCtx)
     }
 
-    override fun <T : KBvSort> visit(sort: T): Long = z3Ctx.internalizeSort(sort) {
+    override fun <T : KBvSort> visit(sort: T) {
         val size = sort.sizeBits.toInt()
-        Native.mkBvSort(nCtx, size)
+        internalizedSort = Native.mkBvSort(nCtx, size)
     }
 
-    override fun <S : KFpSort> visit(sort: S): Long = z3Ctx.internalizeSort(sort) {
-        when (sort) {
+    override fun <S : KFpSort> visit(sort: S) {
+        internalizedSort = when (sort) {
             is KFp16Sort -> Native.mkFpaSort16(nCtx)
             is KFp32Sort -> Native.mkFpaSort32(nCtx)
             is KFp64Sort -> Native.mkFpaSort64(nCtx)
@@ -93,15 +94,18 @@ open class KZ3SortInternalizer(
                 val significand = sort.significandBits.toInt()
                 Native.mkFpaSort(nCtx, exp, significand)
             }
+
             else -> error("Unsupported sort: $sort")
         }
     }
 
-    override fun visit(sort: KUninterpretedSort): Long = z3Ctx.internalizeSort(sort) {
+    override fun visit(sort: KUninterpretedSort) {
         val sortName = Native.mkStringSymbol(nCtx, sort.name)
-        Native.mkUninterpretedSort(nCtx, sortName)
+        internalizedSort = Native.mkUninterpretedSort(nCtx, sortName)
     }
 
-    @Suppress("MemberVisibilityCanBePrivate")
-    fun <T : KSort> T.internalizeZ3Sort() = accept(this@KZ3SortInternalizer)
+    fun internalizeZ3Sort(sort: KSort): Long = z3Ctx.internalizeSort(sort) {
+        sort.accept(this@KZ3SortInternalizer)
+        internalizedSort
+    }
 }

--- a/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/ArrayTest.kt
+++ b/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/ArrayTest.kt
@@ -1,6 +1,7 @@
 package org.ksmt.solver.z3
 
 import com.microsoft.z3.Context
+import com.microsoft.z3.Expr
 import org.ksmt.KContext
 import org.ksmt.expr.KExpr
 import org.ksmt.sort.KSort
@@ -110,18 +111,24 @@ class ArrayTest {
             val z3ConvertCtx = KZ3Context(z3Native)
 
             with(KZ3ExprInternalizer(ctx, z3InternCtx)) {
-                val iConst = const.internalizeExprWrapped().simplify()
-                val iSelect = select.internalizeExprWrapped().simplify()
-                val iStore = store.internalizeExprWrapped().simplify()
-                val iLambda = lambda.internalizeExprWrapped().simplify()
-                val iAsArray = asArray.internalizeExprWrapped().simplify()
+                val iConst = const.internalizeExpr()
+
+                // Simplify const since we use lambdas for n-ary array consts
+                val iConstExpr = z3Native.wrapAST(iConst) as Expr<*>
+                val iConstExprSimplified = iConstExpr.simplify()
+                val iConstSimplified = z3Native.unwrapAST(iConstExprSimplified)
+
+                val iSelect = select.internalizeExpr()
+                val iStore = store.internalizeExpr()
+                val iLambda = lambda.internalizeExpr()
+                val iAsArray = asArray.internalizeExpr()
 
                 with(KZ3ExprConverter(ctx, z3ConvertCtx)) {
-                    val cConst = iConst.convertExprWrapped<KSort>()
-                    val cSelect = iSelect.convertExprWrapped<KSort>()
-                    val cStore = iStore.convertExprWrapped<KSort>()
-                    val cLambda = iLambda.convertExprWrapped<KSort>()
-                    val cAsArray = iAsArray.convertExprWrapped<KSort>()
+                    val cConst = iConstSimplified.convertExpr<KSort>()
+                    val cSelect = iSelect.convertExpr<KSort>()
+                    val cStore = iStore.convertExpr<KSort>()
+                    val cLambda = iLambda.convertExpr<KSort>()
+                    val cAsArray = iAsArray.convertExpr<KSort>()
 
                     assertEquals(const, cConst)
                     assertEquals(select, cSelect)

--- a/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/FloatingPointTest.kt
+++ b/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/FloatingPointTest.kt
@@ -690,13 +690,19 @@ class FloatingPointTest {
     ) = KZ3Context().use { solverInternalCtx ->
         val internalizer = KZ3ExprInternalizer(context, solverInternalCtx)
 
-        val solverInternalSort = with(internalizer) { sort.internalizeSortWrapped() as FPSort }
-        val solverInternalExpr = solverInternal(solverInternalCtx.nativeContext, solverInternalSort)
+        val solverInternalSort = with(internalizer) { sort.internalizeSort() }
+        val solverInternalExpr = solverInternal(
+            solverInternalCtx.nativeContext,
+            solverInternalCtx.nativeContext.wrapAST(solverInternalSort) as FPSort
+        )
 
         val ksmtExpr = operation(sort)
-        val ksmtInternalizedExpr = with(internalizer) { ksmtExpr.internalizeExprWrapped() }
+        val ksmtInternalizedExpr = with(internalizer) { ksmtExpr.internalizeExpr() }
 
-        val check = solverInternalCtx.nativeContext.mkEq(solverInternalExpr, ksmtInternalizedExpr)
+        val check = solverInternalCtx.nativeContext.mkEq(
+            solverInternalExpr,
+            solverInternalCtx.nativeContext.wrapAST(ksmtInternalizedExpr) as Expr<*>
+        )
 
         val checker = solverInternalCtx.nativeContext.mkSolver()
         checker.add(check)


### PR DESCRIPTION
### Specialize internalizers
Get rid of primitives boxing during the internalization process and in solvers internalization contexts. Reduce caches memory usage (store primitive values instead of boxed ones) and improve performance (no boxing/unboxing). 

* Specialized versions of the Internalizer/Converter for natives, represented as Long. Used in Z3 and Bitwuzla.
* Specialized version of the Internalizer for natives, represented as Int. Used in AstSerializer and can be used in Yices.

### Better Z3 internalizer
Completely remove expression wrapping 

### Performance and memory usage improvement
Considering Z3 iternalizer we have the following changes in the internalization performance and memory usage

#### Performance
According to our internalization benchmark `Z3ConverterBenchmark.measureKsmtAssertionTime` we have about 10% performance improvement (`72.695 +- 0.493` before, `64.840 +- 0.342` after). Since most of the time is spent on a native calls, this improvement is significant. 

#### Memory usage
Memory usage analysis is performed on the VM with the following parameters:
```
64-bit HotSpot VM
Objects are 8 bytes aligned.
Field sizes by type: 4, 1, 1, 2, 2, 4, 4, 8, 8 [bytes]
Array element sizes: 4, 1, 1, 2, 2, 4, 4, 8, 8 [bytes]
```
Summing up, object reference size is 4 bytes and primitive long size is 8 bytes.

For the current `HashMap` based implementation we have the following object layouts:
```
java.util.HashMap object internals:
OFFSET  SIZE                         TYPE DESCRIPTION
    36     4   java.util.HashMap.Node[] HashMap.table
    .....

java.util.HashMap$Node object internals:
 OFFSET  SIZE                     TYPE DESCRIPTION                               
      0     4                          (object header)                           
      4     4                          (object header)                           
      8     4                          (object header)                           
     12     4                      int Node.hash                                 
     16     4         java.lang.Object Node.key                                  
     20     4         java.lang.Object Node.value                                
     24     4   java.util.HashMap.Node Node.next                                 
     28     4                          (loss due to the next object alignment)
Instance size: 32 bytes

java.lang.Long object internals:
 OFFSET  SIZE   TYPE DESCRIPTION                               
      0     4        (object header)                           
      4     4        (object header)                           
      8     4        (object header)                           
     12     4        (alignment/padding gap)                  
     16     8   long Long.value                                
Instance size: 24 bytes
```
Data is stored as a single array of `HashMap.Node` objects which is 32 bytes per entry. Since value is an object, 24 bytes are also used to store `Long`. Summing up, 60 bytes are used for each entry (4 bytes for `HashMap.Node` reference + 32 bytes for `HashMap.Node` instance + 24 bytes for `Long` instance).

For the proposed `Object2LongOpenHashMap` based implementation we have the following object layouts:
```
it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap object internals:
 OFFSET  SIZE                    TYPE DESCRIPTION
     48     4                             java.lang.Object[] Object2LongOpenHashMap.key                
     52     4                             long[] Object2LongOpenHashMap.value              
     ......
```
Since data is represented as two arrays without wrapping, only 12 (4 for key reference and 8 for long) bytes are used.

Summing up, the proposed implementation uses 5 times less memory.

### Possible issues
We have a new dependency on `fastutil-core` which is 6Mb in size. Therefore, this may become an issue when creating single jar distributions. 

Possible solutions:
* Shrink the resulting jar with tools like `ProGuard`
* Relocate required classes with `shadow` plugin
