### PR TITLE
Downgrade z3 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ repositories {
 }
 
 // core 
-implementation("com.github.UnitTestBot.ksmt:ksmt-core:0.4.1")
+implementation("com.github.UnitTestBot.ksmt:ksmt-core:0.4.2")
 // z3 solver
-implementation("com.github.UnitTestBot.ksmt:ksmt-z3:0.4.1")
+implementation("com.github.UnitTestBot.ksmt:ksmt-z3:0.4.2")
 ```
 
 ## Usage

--- a/buildSrc/src/main/kotlin/org.ksmt.ksmt-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/org.ksmt.ksmt-base.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "org.ksmt"
-version = "0.4.1"
+version = "0.4.2"
 
 repositories {
     mavenCentral()

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ repositories {
 ```kotlin
 dependencies {
     // core 
-    implementation("com.github.UnitTestBot.ksmt:ksmt-core:0.4.1")    
+    implementation("com.github.UnitTestBot.ksmt:ksmt-core:0.4.2")    
 }
 ```
 
@@ -26,9 +26,9 @@ dependencies {
 ```kotlin
 dependencies {
     // z3 
-    implementation("com.github.UnitTestBot.ksmt:ksmt-z3:0.4.1")
+    implementation("com.github.UnitTestBot.ksmt:ksmt-z3:0.4.2")
     // bitwuzla
-    implementation("com.github.UnitTestBot.ksmt:ksmt-bitwuzla:0.4.1")
+    implementation("com.github.UnitTestBot.ksmt:ksmt-bitwuzla:0.4.2")
 }
 ```
 SMT solver specific packages are provided with solver native binaries. 

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -10,9 +10,9 @@ repositories {
 
 dependencies {
     // core
-    implementation("com.github.UnitTestBot.ksmt:ksmt-core:0.4.1")
+    implementation("com.github.UnitTestBot.ksmt:ksmt-core:0.4.2")
     // z3 solver
-    implementation("com.github.UnitTestBot.ksmt:ksmt-z3:0.4.1")
+    implementation("com.github.UnitTestBot.ksmt:ksmt-z3:0.4.2")
 }
 
 java {

--- a/ksmt-z3/build.gradle.kts
+++ b/ksmt-z3/build.gradle.kts
@@ -9,13 +9,13 @@ repositories {
     mavenCentral()
 }
 
-val z3Version = "4.12.1"
+val z3Version = "4.11.2"
 
 val z3JavaJar by lazy { mkZ3ReleaseDownloadTask("x64-win", "*.jar") }
 
 val z3Binaries = listOf(
     mkZ3ReleaseDownloadTask("x64-win", "*.dll"),
-    mkZ3ReleaseDownloadTask("x64-glibc-2.35", "*.so"),
+    mkZ3ReleaseDownloadTask("x64-glibc-2.31", "*.so"),
     mkZ3ReleaseDownloadTask("x64-osx-10.16", "*.dylib"),
     mkZ3ReleaseDownloadTask("arm64-osx-11.0", "*.dylib")
 )


### PR DESCRIPTION
Downgrade `Z3` version in order to support OS with max `glibc` version of `2.31` 