### PR TITLE
Change the way of native library storing

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     name: Run tests
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     runs-on: ${{ matrix.os }}
 

--- a/buildSrc/src/main/kotlin/ResourseNames.kt
+++ b/buildSrc/src/main/kotlin/ResourseNames.kt
@@ -1,0 +1,10 @@
+import org.gradle.api.artifacts.ResolvedArtifact
+
+fun constructLibraryFolderNameByArtifact(artifact: ResolvedArtifact): String {
+    val name = when {
+        artifact.name.contains("win") -> "windows"
+        artifact.name.contains("linux") -> "linux"
+        else -> error("Unsupported system ${artifact.name}")
+    }
+    return name
+}

--- a/ksmt-bitwuzla/build.gradle.kts
+++ b/ksmt-bitwuzla/build.gradle.kts
@@ -24,8 +24,10 @@ tasks.withType<KotlinCompile> {
 
 tasks.withType<ProcessResources> {
     bitwuzlaNative.resolvedConfiguration.resolvedArtifacts.forEach { artifact ->
+        val name = constructLibraryFolderNameByArtifact(artifact)
+
         from(zipTree(artifact.file)) {
-            into("lib/x64")
+            into("lib/x64/$name")
         }
     }
 }
@@ -37,4 +39,5 @@ publishing {
             artifact(tasks["kotlinSourcesJar"])
         }
     }
+
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/utils/NativeLibraryLoader.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/utils/NativeLibraryLoader.kt
@@ -25,9 +25,11 @@ object NativeLibraryLoader {
 
         val librariesToLoad = libraries(os)
 
+        val folderName = constructFolderName(os, arch)
+
         for (libName in librariesToLoad) {
             val osLibName = libName + libraryExt
-            val resourceName = "lib/x64/$osLibName"
+            val resourceName = "lib/x64/$folderName/$osLibName"
             val libUri = NativeLibraryLoader::class.java.classLoader
                 .getResource(resourceName)
                 ?.toURI()
@@ -53,5 +55,11 @@ object NativeLibraryLoader {
             // tmp files are not removed on Windows
             libFile.toFile().delete()
         }
+    }
+
+    private fun constructFolderName(os: OS, arch: String) = when (os) {
+        OS.WINDOWS -> "windows"
+        OS.LINUX -> "linux"
+        OS.MACOS -> if (arch == "aarch64") "macArm" else "mac64"
     }
 }

--- a/ksmt-cvc5/build.gradle.kts
+++ b/ksmt-cvc5/build.gradle.kts
@@ -29,8 +29,10 @@ tasks.withType<ProcessResources> {
     dependsOn(tasks.compileJava)
 
     cvc5NativeLib.resolvedConfiguration.resolvedArtifacts.forEach { artifact ->
+        val name = constructLibraryFolderNameByArtifact(artifact)
+
         from(zipTree(artifact.file)) {
-            into("lib/x64")
+            into("lib/x64/$name")
         }
     }
 }

--- a/ksmt-yices/build.gradle.kts
+++ b/ksmt-yices/build.gradle.kts
@@ -26,7 +26,10 @@ dependencies {
 
 tasks.withType<ProcessResources> {
     yicesNative.resolvedConfiguration.resolvedArtifacts.forEach { artifact ->
-        val destination = "lib/x64"
+        val name = constructLibraryFolderNameByArtifact(artifact)
+
+        val destination = "lib/x64/$name"
+
         from(zipTree(artifact.file)) {
             into(destination)
         }

--- a/ksmt-z3/build.gradle.kts
+++ b/ksmt-z3/build.gradle.kts
@@ -13,11 +13,11 @@ val z3Version = "4.11.2"
 
 val z3JavaJar by lazy { mkZ3ReleaseDownloadTask("x64-win", "*.jar") }
 
-val z3Binaries = listOf(
-    mkZ3ReleaseDownloadTask("x64-win", "*.dll"),
-    mkZ3ReleaseDownloadTask("x64-glibc-2.31", "*.so"),
-    mkZ3ReleaseDownloadTask("x64-osx-10.16", "*.dylib"),
-    mkZ3ReleaseDownloadTask("arm64-osx-11.0", "*.dylib")
+val z3Binaries = mapOf(
+    "windows" to mkZ3ReleaseDownloadTask("x64-win", "*.dll"),
+    "linux" to mkZ3ReleaseDownloadTask("x64-glibc-2.31", "*.so"),
+    "mac64" to mkZ3ReleaseDownloadTask("x64-osx-10.16", "*.dylib"),
+    "macArm" to mkZ3ReleaseDownloadTask("arm64-osx-11.0", "*.dylib")
 )
 
 dependencies {
@@ -28,12 +28,11 @@ dependencies {
 }
 
 tasks.withType<ProcessResources> {
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    dependsOn.addAll(z3Binaries.values)
 
-    dependsOn.addAll(z3Binaries)
-    z3Binaries.forEach { z3BinaryTask ->
+    z3Binaries.forEach { (systemName, z3BinaryTask) ->
         from(z3BinaryTask.outputFiles) {
-            into("lib/x64")
+            into("lib/x64/${systemName}")
         }
     }
 }


### PR DESCRIPTION
Previously, all the native libraries we use were stored in `lib/x64` folder, that led to an error with native libraries for MacOS. Both, libraries for `arm` and `x64` have the same name, so they conflicted and we lost one of the platform.

Now we add a specific, platform and system dependent folder for these native files.

Added `macOS` platform into the main workflow.