### PR TITLE
Expression ordering made TimSort fail

### DIFF
--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/ExpressionOrdering.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/ExpressionOrdering.kt
@@ -18,7 +18,11 @@ object ExpressionOrdering : Comparator<KExpr<*>> {
             else -> -1
         }
 
-        else -> compareDefault(left, right)
+        else -> when(right) {
+            is KInterpretedValue<*> -> 1
+            is KConst<*> -> 1
+            else -> compareDefault(left, right)
+        }
     }
 
     @JvmStatic

--- a/ksmt-core/src/test/kotlin/org/ksmt/expr/rewrite/simplify/ExpressionOrderingTest.kt
+++ b/ksmt-core/src/test/kotlin/org/ksmt/expr/rewrite/simplify/ExpressionOrderingTest.kt
@@ -18,12 +18,10 @@ class ExpressionOrderingTest {
     )
 
     @Test
-    fun testAntisymmetry() {
+    fun testAntisymmetry() = with(ExpressionOrdering) {
         for (value1 in values) {
             for (value2 in values) {
-                assert(
-                    ExpressionOrdering.compare(value1, value2).sign == -ExpressionOrdering.compare(value2, value1).sign
-                ) {
+                assert(compare(value1, value2).sign == -compare(value2, value1).sign) {
                     "Compare $value1 with $value2"
                 }
             }
@@ -40,16 +38,12 @@ class ExpressionOrderingTest {
     }
 
     @Test
-    fun testTransitivity() {
+    fun testTransitivity() = with(ExpressionOrdering) {
         for (value1 in values) {
             for (value2 in values) {
                 for (value3 in values) {
-                    if (ExpressionOrdering.compare(value1, value2) <= 0 && ExpressionOrdering.compare(
-                            value2,
-                            value3
-                        ) <= 0
-                    ) {
-                        assert(ExpressionOrdering.compare(value1, value3) <= 0) {
+                    if (compare(value1, value2) <= 0 && compare(value2, value3) <= 0) {
+                        assert(compare(value1, value3) <= 0) {
                             "Compare $value1 and $value3 when [$value1] <= [$value2] <= [$value3]"
                         }
                     }

--- a/ksmt-core/src/test/kotlin/org/ksmt/expr/rewrite/simplify/ExpressionOrderingTest.kt
+++ b/ksmt-core/src/test/kotlin/org/ksmt/expr/rewrite/simplify/ExpressionOrderingTest.kt
@@ -1,0 +1,60 @@
+package org.ksmt.expr.rewrite.simplify
+
+import org.ksmt.KContext
+import org.ksmt.decl.KIntNumDecl
+import org.ksmt.expr.*
+import kotlin.math.sign
+import kotlin.test.Test
+
+class ExpressionOrderingTest {
+    private val ctx = KContext()
+    private val values = arrayOf(
+        KConst(ctx, KIntNumDecl(ctx, "1")),
+        KConst(ctx, KIntNumDecl(ctx, "2")),
+        KInt32NumExpr(ctx, 3),
+        KInt32NumExpr(ctx, 4),
+        KAddArithExpr(ctx, listOf(KInt32NumExpr(ctx, 10), KInt32NumExpr(ctx, 20))),
+        KAddArithExpr(ctx, listOf(KInt32NumExpr(ctx, 30), KInt32NumExpr(ctx, 40))),
+    )
+
+    @Test
+    fun testAntisymmetry() {
+        for (value1 in values) {
+            for (value2 in values) {
+                assert(
+                    ExpressionOrdering.compare(value1, value2).sign == -ExpressionOrdering.compare(value2, value1).sign
+                ) {
+                    "Compare $value1 with $value2"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testReflexivity() {
+        for (value in values) {
+            assert(ExpressionOrdering.compare(value, value) == 0) {
+                "Compare $value with itself"
+            }
+        }
+    }
+
+    @Test
+    fun testTransitivity() {
+        for (value1 in values) {
+            for (value2 in values) {
+                for (value3 in values) {
+                    if (ExpressionOrdering.compare(value1, value2) <= 0 && ExpressionOrdering.compare(
+                            value2,
+                            value3
+                        ) <= 0
+                    ) {
+                        assert(ExpressionOrdering.compare(value1, value3) <= 0) {
+                            "Compare $value1 and $value3 when [$value1] <= [$value2] <= [$value3]"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ksmt-core/src/test/kotlin/org/ksmt/expr/rewrite/simplify/ExpressionOrderingTest.kt
+++ b/ksmt-core/src/test/kotlin/org/ksmt/expr/rewrite/simplify/ExpressionOrderingTest.kt
@@ -3,18 +3,20 @@ package org.ksmt.expr.rewrite.simplify
 import org.ksmt.KContext
 import org.ksmt.decl.KIntNumDecl
 import org.ksmt.expr.*
+import org.ksmt.utils.mkConst
 import kotlin.math.sign
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 
 class ExpressionOrderingTest {
     private val ctx = KContext()
     private val values = arrayOf(
-        KConst(ctx, KIntNumDecl(ctx, "1")),
-        KConst(ctx, KIntNumDecl(ctx, "2")),
-        KInt32NumExpr(ctx, 3),
-        KInt32NumExpr(ctx, 4),
-        KAddArithExpr(ctx, listOf(KInt32NumExpr(ctx, 10), KInt32NumExpr(ctx, 20))),
-        KAddArithExpr(ctx, listOf(KInt32NumExpr(ctx, 30), KInt32NumExpr(ctx, 40))),
+        ctx.mkConstApp(ctx.mkIntNumDecl("1")),
+        ctx.mkConstApp(ctx.mkIntNumDecl("2")),
+        ctx.mkIntNum(3),
+        ctx.mkIntNum(4),
+        ctx.mkArithAddNoSimplify(listOf(ctx.mkIntNum(10), ctx.mkIntNum(20))),
+        ctx.mkArithAddNoSimplify(listOf(ctx.mkIntNum(30), ctx.mkIntNum(40))),
     )
 
     @Test


### PR DESCRIPTION
The following exception happened: 
```
Exception in thread "main" java.lang.IllegalArgumentException: Comparison method violates its general contract!
	at java.base/java.util.TimSort.mergeLo(TimSort.java:781)
	at java.base/java.util.TimSort.mergeAt(TimSort.java:518)
	at java.base/java.util.TimSort.mergeCollapse(TimSort.java:448)
	at java.base/java.util.TimSort.sort(TimSort.java:245)
	at java.base/java.util.Arrays.sort(Arrays.java:1515)
	at java.base/java.util.ArrayList.sort(ArrayList.java:1750)
	at java.base/java.util.Collections.sort(Collections.java:179)
	at kotlin.collections.CollectionsKt__MutableCollectionsJVMKt.sortWith(MutableCollectionsJVM.kt:42)
	at org.ksmt.expr.rewrite.simplify.ExpressionOrderingKt.ensureExpressionsOrder(ExpressionOrdering.kt:40)
	at org.ksmt.expr.rewrite.simplify.BoolSimplificationKt.simplifyAnd(BoolSimplification.kt:504)
	at org.ksmt.KContext.mkAnd(KContext.kt:680)
	at org.ksmt.KContext.mkAnd$default(KContext.kt:674)
```

The PR adds the test to show the failure and fixes the issue 