### PR TITLE
Faster array select simplification

### DIFF
--- a/buildSrc/src/main/kotlin/org.ksmt.ksmt-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/org.ksmt.ksmt-base.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
     // Primitive collections
     implementation("it.unimi.dsi:fastutil-core:8.5.11") // 6.1MB
 
+    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5")
+
     testImplementation(kotlin("test"))
 }
 

--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaModel.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaModel.kt
@@ -30,11 +30,15 @@ open class KBitwuzlaModel(
     override val declarations: Set<KDecl<*>>
         get() = modelDeclarations.toHashSet()
 
-    override fun <T : KSort> eval(expr: KExpr<T>, isComplete: Boolean): KExpr<T> {
-        ctx.ensureContextMatch(expr)
-        bitwuzlaCtx.ensureActive()
+    private val evaluatorWithModelCompletion by lazy { KModelEvaluator(ctx, this, isComplete = true) }
+    private val evaluatorWithoutModelCompletion by lazy { KModelEvaluator(ctx, this, isComplete = false) }
 
-        return KModelEvaluator(ctx, this, isComplete).apply(expr)
+    override fun <T : KSort> eval(expr: KExpr<T>, isComplete: Boolean): KExpr<T> {
+        bitwuzlaCtx.ensureActive()
+        ctx.ensureContextMatch(expr)
+
+        val evaluator = if (isComplete) evaluatorWithModelCompletion else evaluatorWithoutModelCompletion
+        return evaluator.apply(expr)
     }
 
     private val uninterpretedSortValueContext = KBitwuzlaUninterpretedSortValueContext(ctx)

--- a/ksmt-core/build.gradle.kts
+++ b/ksmt-core/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 }
 
 dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5")
+
     testImplementation(project(":ksmt-z3"))
     testImplementation("org.junit.jupiter", "junit-jupiter-params", "5.8.2")
 }

--- a/ksmt-core/build.gradle.kts
+++ b/ksmt-core/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5")
-
     testImplementation(project(":ksmt-z3"))
     testImplementation("org.junit.jupiter", "junit-jupiter-params", "5.8.2")
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
@@ -998,12 +998,47 @@ open class KContext(
         array: KExpr<KArraySort<D, R>>,
         index: KExpr<D>,
         value: KExpr<R>
+    ): KArrayStore<D, R> =
+        mkArrayStoreNoSimplifyNoAnalyze(array, index, value)
+            .analyzeIfSimplificationEnabled()
+
+    open fun <D0 : KSort, D1 : KSort, R : KSort> mkArrayStoreNoSimplify(
+        array: KExpr<KArray2Sort<D0, D1, R>>,
+        index0: KExpr<D0>,
+        index1: KExpr<D1>,
+        value: KExpr<R>
+    ): KArray2Store<D0, D1, R> =
+        mkArrayStoreNoSimplifyNoAnalyze(array, index0, index1, value)
+            .analyzeIfSimplificationEnabled()
+
+    open fun <D0 : KSort, D1 : KSort, D2 : KSort, R : KSort> mkArrayStoreNoSimplify(
+        array: KExpr<KArray3Sort<D0, D1, D2, R>>,
+        index0: KExpr<D0>,
+        index1: KExpr<D1>,
+        index2: KExpr<D2>,
+        value: KExpr<R>
+    ): KArray3Store<D0, D1, D2, R> =
+        mkArrayStoreNoSimplifyNoAnalyze(array, index0, index1, index2, value)
+            .analyzeIfSimplificationEnabled()
+
+    open fun <R : KSort> mkArrayNStoreNoSimplify(
+        array: KExpr<KArrayNSort<R>>,
+        indices: List<KExpr<*>>,
+        value: KExpr<R>
+    ): KArrayNStore<R> =
+        mkArrayNStoreNoSimplifyNoAnalyze(array, indices, value)
+            .analyzeIfSimplificationEnabled()
+
+    open fun <D : KSort, R : KSort> mkArrayStoreNoSimplifyNoAnalyze(
+        array: KExpr<KArraySort<D, R>>,
+        index: KExpr<D>,
+        value: KExpr<R>
     ): KArrayStore<D, R> = arrayStoreCache.createIfContextActive {
         ensureContextMatch(array, index, value)
         KArrayStore(this, array, index, value)
-    }.analyzeIfSimplificationEnabled().cast()
+    }.cast()
 
-    open fun <D0 : KSort, D1 : KSort, R : KSort> mkArrayStoreNoSimplify(
+    open fun <D0 : KSort, D1 : KSort, R : KSort> mkArrayStoreNoSimplifyNoAnalyze(
         array: KExpr<KArray2Sort<D0, D1, R>>,
         index0: KExpr<D0>,
         index1: KExpr<D1>,
@@ -1011,9 +1046,9 @@ open class KContext(
     ): KArray2Store<D0, D1, R> = array2StoreCache.createIfContextActive {
         ensureContextMatch(array, index0, index1, value)
         KArray2Store(this, array, index0, index1, value)
-    }.analyzeIfSimplificationEnabled().cast()
+    }.cast()
 
-    open fun <D0 : KSort, D1 : KSort, D2 : KSort, R : KSort> mkArrayStoreNoSimplify(
+    open fun <D0 : KSort, D1 : KSort, D2 : KSort, R : KSort> mkArrayStoreNoSimplifyNoAnalyze(
         array: KExpr<KArray3Sort<D0, D1, D2, R>>,
         index0: KExpr<D0>,
         index1: KExpr<D1>,
@@ -1022,9 +1057,9 @@ open class KContext(
     ): KArray3Store<D0, D1, D2, R> = array3StoreCache.createIfContextActive {
         ensureContextMatch(array, index0, index1, index2, value)
         KArray3Store(this, array, index0, index1, index2, value)
-    }.analyzeIfSimplificationEnabled().cast()
+    }.cast()
 
-    open fun <R : KSort> mkArrayNStoreNoSimplify(
+    open fun <R : KSort> mkArrayNStoreNoSimplifyNoAnalyze(
         array: KExpr<KArrayNSort<R>>,
         indices: List<KExpr<*>>,
         value: KExpr<R>
@@ -1033,7 +1068,7 @@ open class KContext(
         ensureContextMatch(array, value)
 
         KArrayNStore(this, array, indices.uncheckedCast(), value)
-    }.analyzeIfSimplificationEnabled().cast()
+    }.cast()
 
     private fun <S : KArrayStoreBase<*, *>> S.analyzeIfSimplificationEnabled(): S {
         /**

--- a/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
@@ -160,6 +160,7 @@ import org.ksmt.expr.KArrayNSelect
 import org.ksmt.expr.KArrayNStore
 import org.ksmt.expr.KArraySelect
 import org.ksmt.expr.KArrayStore
+import org.ksmt.expr.KArrayStoreBase
 import org.ksmt.expr.KBitVec16Value
 import org.ksmt.expr.KBitVec1Value
 import org.ksmt.expr.KBitVec32Value
@@ -1000,7 +1001,7 @@ open class KContext(
     ): KArrayStore<D, R> = arrayStoreCache.createIfContextActive {
         ensureContextMatch(array, index, value)
         KArrayStore(this, array, index, value)
-    }.also { it.analyzeStore() }.cast()
+    }.analyzeIfSimplificationEnabled().cast()
 
     open fun <D0 : KSort, D1 : KSort, R : KSort> mkArrayStoreNoSimplify(
         array: KExpr<KArray2Sort<D0, D1, R>>,
@@ -1010,7 +1011,7 @@ open class KContext(
     ): KArray2Store<D0, D1, R> = array2StoreCache.createIfContextActive {
         ensureContextMatch(array, index0, index1, value)
         KArray2Store(this, array, index0, index1, value)
-    }.also { it.analyzeStore() }.cast()
+    }.analyzeIfSimplificationEnabled().cast()
 
     open fun <D0 : KSort, D1 : KSort, D2 : KSort, R : KSort> mkArrayStoreNoSimplify(
         array: KExpr<KArray3Sort<D0, D1, D2, R>>,
@@ -1021,7 +1022,7 @@ open class KContext(
     ): KArray3Store<D0, D1, D2, R> = array3StoreCache.createIfContextActive {
         ensureContextMatch(array, index0, index1, index2, value)
         KArray3Store(this, array, index0, index1, index2, value)
-    }.also { it.analyzeStore() }.cast()
+    }.analyzeIfSimplificationEnabled().cast()
 
     open fun <R : KSort> mkArrayNStoreNoSimplify(
         array: KExpr<KArrayNSort<R>>,
@@ -1032,7 +1033,19 @@ open class KContext(
         ensureContextMatch(array, value)
 
         KArrayNStore(this, array, indices.uncheckedCast(), value)
-    }.also { it.analyzeStore() }.cast()
+    }.analyzeIfSimplificationEnabled().cast()
+
+    private fun <S : KArrayStoreBase<*, *>> S.analyzeIfSimplificationEnabled(): S {
+        /**
+         * Analyze store indices only when simplification is enabled since
+         * we don't expect any benefit from the analyzed stores
+         * if we don't use simplifications.
+         * */
+        if (simplificationMode == SIMPLIFY) {
+            analyzeStore()
+        }
+        return this
+    }
 
     private val arraySelectCache = mkAstInterner<KArraySelect<out KSort, out KSort>>()
     private val array2SelectCache = mkAstInterner<KArray2Select<out KSort, out KSort, out KSort>>()

--- a/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
@@ -1000,7 +1000,7 @@ open class KContext(
     ): KArrayStore<D, R> = arrayStoreCache.createIfContextActive {
         ensureContextMatch(array, index, value)
         KArrayStore(this, array, index, value)
-    }.cast()
+    }.also { it.analyzeStore() }.cast()
 
     open fun <D0 : KSort, D1 : KSort, R : KSort> mkArrayStoreNoSimplify(
         array: KExpr<KArray2Sort<D0, D1, R>>,
@@ -1010,7 +1010,7 @@ open class KContext(
     ): KArray2Store<D0, D1, R> = array2StoreCache.createIfContextActive {
         ensureContextMatch(array, index0, index1, value)
         KArray2Store(this, array, index0, index1, value)
-    }.cast()
+    }.also { it.analyzeStore() }.cast()
 
     open fun <D0 : KSort, D1 : KSort, D2 : KSort, R : KSort> mkArrayStoreNoSimplify(
         array: KExpr<KArray3Sort<D0, D1, D2, R>>,
@@ -1021,7 +1021,7 @@ open class KContext(
     ): KArray3Store<D0, D1, D2, R> = array3StoreCache.createIfContextActive {
         ensureContextMatch(array, index0, index1, index2, value)
         KArray3Store(this, array, index0, index1, index2, value)
-    }.cast()
+    }.also { it.analyzeStore() }.cast()
 
     open fun <R : KSort> mkArrayNStoreNoSimplify(
         array: KExpr<KArrayNSort<R>>,
@@ -1032,7 +1032,7 @@ open class KContext(
         ensureContextMatch(array, value)
 
         KArrayNStore(this, array, indices.uncheckedCast(), value)
-    }.cast()
+    }.also { it.analyzeStore() }.cast()
 
     private val arraySelectCache = mkAstInterner<KArraySelect<out KSort, out KSort>>()
     private val array2SelectCache = mkAstInterner<KArray2Select<out KSort, out KSort, out KSort>>()

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/Array.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/Array.kt
@@ -20,6 +20,35 @@ import org.ksmt.sort.KSort
 import org.ksmt.utils.asExpr
 import org.ksmt.utils.uncheckedCast
 
+/**
+ * Base expression for various array store expressions
+ * with interpreted indices cache support.
+ *
+ * Array store indices caches allows faster array select simplification
+ * in a case when many stored indices are interpreted values.
+ * By default, caches are ENABLED when simplifications are enabled in [KContext].
+ *
+ * Array store caches memory impact.
+ * In a case when we have long chains of array stores with
+ * interpreted values memory usage may become significant.
+ * We expect the maximum memory usage overhead to be about
+ * `1.4 * #array dimensions` per store expression.
+ * For example, in a case of two dimensional arrays,
+ * if we denote normal array store expression memory usage as `M`
+ * the caches will use at most `1.4 * 2 * M` of additional memory.
+ *
+ * Manual control of array store caches.
+ * Since the memory usage overhead can become huge in some scenarios,
+ * it is possible to manually manage caching.
+ * 1. Disable array store cache initialization by default.
+ * By default, cache initialization is performed in [KContext.mkArrayStoreNoSimplify]
+ * after expression creation.
+ * To disable cache initialization, you can
+ * override [KContext.mkArrayStoreNoSimplify] and
+ * invoke [KContext.mkArrayStoreNoSimplifyNoAnalyze] directly.
+ * 2. Manually enable caching for some array store expressions.
+ * To initialize cache you can invoke [KArrayStoreBase.analyzeStore] anytime.
+ * */
 sealed class KArrayStoreBase<A : KArraySortBase<R>, R : KSort>(
     ctx: KContext,
     val array: KExpr<A>,

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/Array.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/Array.kt
@@ -73,6 +73,10 @@ sealed class KArrayStoreBase<A : KArraySortBase<R>, R : KSort>(
         /**
          * Current store is the first store with interpreted indices.
          * We don't need to initialize map.
+         *
+         * Note: when the nested array is an array store expression
+         * we can't skip it in the indices lookup chain because it
+         * contains uninterpreted indices.
          * */
         if (array !is KArrayStoreBase<A, *> || array.type != ArrayStoreType.INTERPRETED) {
             nextUninterpretedArray = array
@@ -120,6 +124,12 @@ sealed class KArrayStoreBase<A : KArraySortBase<R>, R : KSort>(
         // On a small store chains linear lookup is faster than map lookup.
         private const val LINEAR_LOOKUP_THRESHOLD = 7
 
+        /**
+         * Analyzed array store type.
+         * [NOT_INITIALIZED] --- array was not analyzed yet.
+         * [INTERPRETED] --- all array store indices are interpreted values.
+         * [UNINTERPRETED] --- at least one of the array store indices is not an interpreted value.
+         * */
         internal enum class ArrayStoreType {
             INTERPRETED,
             UNINTERPRETED,

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/Array.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/Array.kt
@@ -112,7 +112,7 @@ sealed class KArrayStoreBase<A : KArraySortBase<R>, R : KSort>(
         ?: persistentHashMapOf<Any, KArrayStoreBase<A, *>>().mutate { map ->
             map[createLookupKey()] = this
             linearlyTraverseArray(nestedInterpretedStore) { nestedArray ->
-                map[nestedArray.createLookupKey()] = nestedArray
+                map.putIfAbsent(nestedArray.createLookupKey(), nestedArray)
             }
         }
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/ArithSimplification.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/ArithSimplification.kt
@@ -15,6 +15,7 @@ import org.ksmt.sort.KRealSort
 import org.ksmt.utils.ArithUtils.RealValue
 import org.ksmt.utils.ArithUtils.bigIntegerValue
 import org.ksmt.utils.ArithUtils.compareTo
+import org.ksmt.utils.ArithUtils.modWithNegativeNumbers
 import org.ksmt.utils.ArithUtils.numericValue
 import org.ksmt.utils.ArithUtils.toRealValue
 import org.ksmt.utils.uncheckedCast
@@ -198,7 +199,7 @@ fun KContext.simplifyIntMod(lhs: KExpr<KIntSort>, rhs: KExpr<KIntSort>): KExpr<K
         }
 
         if (rValue != BigInteger.ZERO && lhs is KIntNumExpr) {
-            return mkIntNum(lhs.bigIntegerValue.mod(rValue))
+            return mkIntNum(modWithNegativeNumbers(lhs.bigIntegerValue, rValue))
         }
     }
     return mkIntModNoSimplify(lhs, rhs)

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/ArraySimplification.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/ArraySimplification.kt
@@ -216,6 +216,17 @@ fun <R : KSort> KContext.simplifyArrayNSelect(
 )
 
 @Suppress("LoopWithTooManyJumpStatements")
+/**
+ * Simplify select from a chain on array store expressions.
+ *
+ * If array stores are not analyzed (see [KArrayStoreBase.analyzeStore])
+ * this operation will traverse whole array store chain.
+ * Otherwise, we speed up the traversal with [KArrayStoreBase.findArrayToSelectFrom].
+ * In the case of a one-dimensional arrays, this operation is guaranteed
+ * to perform only one iteration of the loop (constant).
+ * For the multi-dimensional arrays, usually only a few iterations will be performed,
+ * but in the worst case we may traverse the entire stores chain.
+ * */
 inline fun <
     A : KArraySortBase<R>,
     R : KSort,

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/ArraySimplification.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/ArraySimplification.kt
@@ -217,7 +217,7 @@ fun <R : KSort> KContext.simplifyArrayNSelect(
 
 @Suppress("LoopWithTooManyJumpStatements")
 /**
- * Simplify select from a chain on array store expressions.
+ * Simplify select from a chain of array store expressions.
  *
  * If array stores are not analyzed (see [KArrayStoreBase.analyzeStore])
  * this operation will traverse whole array store chain.

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/KArrayExprSimplifier.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/KArrayExprSimplifier.kt
@@ -745,6 +745,7 @@ interface KArrayExprSimplifier : KExprSimplifierBase {
             )
         }
 
+    @Suppress("LongParameterList", "LoopWithTooManyJumpStatements")
     private inline fun <
         A : KArraySortBase<R>,
         R : KSort,

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/KExprSimplifierBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/KExprSimplifierBase.kt
@@ -3,6 +3,7 @@ package org.ksmt.expr.rewrite.simplify
 import org.ksmt.expr.KExpr
 import org.ksmt.expr.transformer.KTransformer
 import org.ksmt.sort.KSort
+import org.ksmt.utils.uncheckedCast
 
 interface KExprSimplifierBase : KTransformer {
     /**
@@ -58,3 +59,16 @@ internal fun <T : KSort> KExprSimplifierBase.boundedRewrite(
     expr: SimplifierAuxExpression<T>,
     depth: Int = SIMPLIFIER_DEFAULT_BOUNDED_REWRITE_DEPTH
 ): KExpr<T> = boundedRewrite(depth, expr.expr)
+
+/**
+ * [left] and [right] are definitely distinct if there
+ * is at least one distinct pair of expressions.
+ * */
+fun KExprSimplifierBase.areDefinitelyDistinct(left: List<KExpr<*>>, right: List<KExpr<*>>): Boolean {
+    for (i in left.indices) {
+        val lhs: KExpr<KSort> = left[i].uncheckedCast()
+        val rhs: KExpr<KSort> = right[i].uncheckedCast()
+        if (areDefinitelyDistinct(lhs, rhs)) return true
+    }
+    return false
+}

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/KExprSimplifierBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/KExprSimplifierBase.kt
@@ -65,6 +65,10 @@ internal fun <T : KSort> KExprSimplifierBase.boundedRewrite(
  * is at least one distinct pair of expressions.
  * */
 fun KExprSimplifierBase.areDefinitelyDistinct(left: List<KExpr<*>>, right: List<KExpr<*>>): Boolean {
+    check(left.size == right.size) {
+        "Pairwise distinct check requires both lists to be the same size"
+    }
+
     for (i in left.indices) {
         val lhs: KExpr<KSort> = left[i].uncheckedCast()
         val rhs: KExpr<KSort> = right[i].uncheckedCast()

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/model/KModelEvaluator.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/model/KModelEvaluator.kt
@@ -202,6 +202,13 @@ open class KModelEvaluator(
         return expr in sortUniverse
     }
 
+    private fun isValueInModel(expr: KExpr<*>): Boolean {
+        if (expr is KInterpretedValue<*>) return true
+        val sort = expr.sort
+        if (sort is KUninterpretedSort && isUninterpretedValue(sort, expr.uncheckedCast())) return true
+        return false
+    }
+
     @Suppress("USELESS_CAST") // Exhaustive when
     private fun <A : KArraySortBase<R>, R : KSort> evalArrayInterpretation(
         sort: A,
@@ -324,7 +331,7 @@ open class KModelEvaluator(
             }
         }
 
-        val argsAreConstants = args.all { it is KInterpretedValue<*> }
+        val argsAreConstants = args.all { isValueInModel(it) }
 
         val resolvedEntries = arrayListOf<KModel.KFuncInterpEntry<T>>()
         for (entry in interpretation.entries) {
@@ -341,7 +348,7 @@ open class KModelEvaluator(
                 )
             }
 
-            val definitelyDontMatch = argsAreConstants && entryArgs.all { it is KInterpretedValue<*> }
+            val definitelyDontMatch = argsAreConstants && entryArgs.all { isValueInModel(it) }
             if (definitelyDontMatch) {
                 // No need to keep entry, since it doesn't match arguments
                 continue

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/model/KModelEvaluator.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/model/KModelEvaluator.kt
@@ -36,8 +36,9 @@ open class KModelEvaluator(
     private val isComplete: Boolean,
     private val quantifiedVars: Set<KDecl<*>> = emptySet()
 ) : KExprSimplifier(ctx) {
-    private val evaluatedFunctionApp: MutableMap<Pair<KDecl<*>, List<KExpr<*>>>, KExpr<*>> = hashMapOf()
-    private val evaluatedFunctionArray: MutableMap<KDecl<*>, KExpr<*>> = hashMapOf()
+    private val evaluatedFunctionApp = hashMapOf<Pair<KDecl<*>, List<KExpr<*>>>, KExpr<*>>()
+    private val evaluatedFunctionArray = hashMapOf<KDecl<*>, KExpr<*>>()
+    private val resolvedFunctionInterpretations = hashMapOf<KModel.KFuncInterp<*>, ResolvedFunctionInterpretation<*>>()
 
     override fun <T : KSort> transform(expr: KFunctionApp<T>): KExpr<T> =
         simplifyExpr(expr, expr.args) { args ->
@@ -290,81 +291,13 @@ open class KModelEvaluator(
                 "${interpretation.vars.size} arguments expected but ${args.size} provided"
             }
 
-            val resolvedInterpretation = ctx.resolveFunctionInterpretationComplete(interpretation, args)
-
-            // Interpretation was fully resolved
-            if (resolvedInterpretation.entries.isEmpty() && resolvedInterpretation.default != null) {
-                return@getOrPut resolvedInterpretation.default
+            val resolvedInterpretation = resolvedFunctionInterpretations.getOrPut(interpretation) {
+                resolveFunctionInterpretation(interpretation)
             }
 
-            // Interpretation was not fully resolved --> generate ITE chain
-            evalResolvedFunctionInterpretation(resolvedInterpretation, args)
+            ctx.applyResolvedInterpretation(resolvedInterpretation, args)
         }
         return evaluated.asExpr(decl.sort)
-    }
-
-    private fun <T : KSort> evalResolvedFunctionInterpretation(
-        resolvedInterpretation: KModel.KFuncInterp<T>,
-        args: List<KExpr<*>>
-    ): KExpr<T> = with(ctx) {
-        // in case of partial interpretation we can generate any default expr to preserve expression correctness
-        val defaultExpr = resolvedInterpretation.default ?: completeModelValue(resolvedInterpretation.sort)
-        return resolvedInterpretation.entries.foldRight(defaultExpr) { entry, acc ->
-            val argBinding = entry.args.zip(args) { ea, a ->
-                val entryArg: KExpr<KSort> = ea.uncheckedCast()
-                val actualArg: KExpr<KSort> = a.uncheckedCast()
-                mkEq(entryArg, actualArg)
-            }
-            mkIte(mkAnd(argBinding), entry.value, acc)
-        }
-    }
-
-    private fun <T : KSort> KContext.resolveFunctionInterpretationComplete(
-        interpretation: KModel.KFuncInterp<T>,
-        args: List<KExpr<*>>
-    ): KModel.KFuncInterp<T> {
-        // Replace function parameters vars with actual arguments
-        val varSubstitution = KExprSubstitutor(ctx).apply {
-            interpretation.vars.zip(args).forEach { (v, a) ->
-                val app: KExpr<KSort> = mkConstApp(v).uncheckedCast()
-                substitute(app, a.uncheckedCast())
-            }
-        }
-
-        val argsAreConstants = args.all { isValueInModel(it) }
-
-        val resolvedEntries = arrayListOf<KModel.KFuncInterpEntry<T>>()
-        for (entry in interpretation.entries) {
-            val entryArgs = entry.args.map { varSubstitution.apply(it) }
-            val entryValue = varSubstitution.apply(entry.value)
-
-            if (resolvedEntries.isEmpty() && entryArgs == args) {
-                // We have no possibly matching entries and we found a matched entry
-                return KModel.KFuncInterp(
-                    decl = interpretation.decl,
-                    vars = interpretation.vars,
-                    entries = emptyList(),
-                    default = entryValue
-                )
-            }
-
-            val definitelyDontMatch = argsAreConstants && entryArgs.all { isValueInModel(it) }
-            if (definitelyDontMatch) {
-                // No need to keep entry, since it doesn't match arguments
-                continue
-            }
-
-            resolvedEntries += KModel.KFuncInterpEntry(entryArgs, entryValue)
-        }
-
-        val resolvedDefault = interpretation.default?.let { varSubstitution.apply(it) }
-
-        return KModel.KFuncInterp(
-            decl = interpretation.decl,
-            vars = interpretation.vars,
-            entries = resolvedEntries,
-            default = resolvedDefault
-        )
     }
 
     private fun <T : KSort> completeModelValue(sort: T): KExpr<T> {
@@ -383,4 +316,183 @@ open class KModelEvaluator(
         }
         return value.asExpr(sort)
     }
+
+    private fun <T : KSort> resolveFunctionInterpretation(
+        interpretation: KModel.KFuncInterp<T>
+    ): ResolvedFunctionInterpretation<T> {
+        var resolvedEntry: ResolvedFunctionEntry<T> = ResolvedFunctionDefaultEntry(interpretation.default)
+
+        for (entry in interpretation.entries.asReversed()) {
+            val isValueEntry = entry.args.all { isValueInModel(it) }
+
+            resolvedEntry = if (isValueEntry) {
+                resolvedEntry.addValueEntry(entry.args, entry.value)
+            } else {
+                resolvedEntry.addUninterpretedEntry(entry.args, entry.value)
+            }
+        }
+
+        return ResolvedFunctionInterpretation(interpretation, resolvedEntry)
+    }
+
+    private fun <T : KSort> KContext.applyResolvedInterpretation(
+        interpretation: ResolvedFunctionInterpretation<T>,
+        args: List<KExpr<*>>
+    ): KExpr<T> {
+        val argsAreConstants = args.all { isValueInModel(it) }
+
+        // Replace function parameters vars with actual arguments
+        val varSubstitution = createVariableSubstitution(interpretation, args)
+
+        val resultEntries = mutableListOf<Pair<List<KExpr<*>>, KExpr<T>>>()
+
+        var currentEntries = interpretation.rootEntry
+        while (true) {
+            when (currentEntries) {
+                is ResolvedFunctionUninterpretedEntry -> {
+                    currentEntries.tryResolveArgs(
+                        varSubstitution, args, resultEntries
+                    )?.let { return it }
+
+                    currentEntries = currentEntries.next
+                }
+
+                is ResolvedFunctionValuesEntry -> {
+                    currentEntries.tryResolveArgs(
+                        varSubstitution, args, argsAreConstants, resultEntries
+                    )?.let { return it }
+
+                    currentEntries = currentEntries.next
+                }
+
+                is ResolvedFunctionDefaultEntry -> return currentEntries.resolveArgs(
+                    interpretation.interpretation.sort,
+                    varSubstitution, args, resultEntries
+                )
+            }
+        }
+    }
+
+    private fun KContext.createVariableSubstitution(
+        interpretation: ResolvedFunctionInterpretation<*>,
+        args: List<KExpr<*>>
+    ) = KExprSubstitutor(this).apply {
+        interpretation.interpretation.vars.zip(args).forEach { (v, a) ->
+            val app: KExpr<KSort> = mkConstApp(v).uncheckedCast()
+            substitute(app, a.uncheckedCast())
+        }
+    }
+
+    private fun <T : KSort> rewriteFunctionAppAsIte(
+        base: KExpr<T>,
+        args: List<KExpr<*>>,
+        entries: List<Pair<List<KExpr<*>>, KExpr<T>>>
+    ): KExpr<T> = with(ctx) {
+        entries.foldRight(base) { entry, acc ->
+            val argBinding = entry.first.zip(args) { ea, a ->
+                val entryArg: KExpr<KSort> = ea.uncheckedCast()
+                val actualArg: KExpr<KSort> = a.uncheckedCast()
+                mkEq(entryArg, actualArg)
+            }
+            mkIte(mkAnd(argBinding), entry.second, acc)
+        }
+    }
+
+    private fun <T : KSort> ResolvedFunctionDefaultEntry<T>.resolveArgs(
+        sort: T,
+        varSubstitution: KExprSubstitutor,
+        args: List<KExpr<*>>,
+        resultEntries: List<Pair<List<KExpr<*>>, KExpr<T>>>
+    ): KExpr<T> {
+        val resolvedDefault = expr?.let { varSubstitution.apply(it) }
+
+        // in case of partial interpretation we can generate any default expr to preserve expression correctness
+        val defaultExpr = resolvedDefault ?: completeModelValue(sort)
+
+        return rewriteFunctionAppAsIte(defaultExpr, args, resultEntries)
+    }
+
+    private fun <T : KSort> ResolvedFunctionValuesEntry<T>.tryResolveArgs(
+        varSubstitution: KExprSubstitutor,
+        args: List<KExpr<*>>,
+        argsAreConstants: Boolean,
+        resultEntries: MutableList<Pair<List<KExpr<*>>, KExpr<T>>>
+    ): KExpr<T>? {
+        if (argsAreConstants) {
+            val entryValue = entries[args]?.let { varSubstitution.apply(it) }
+            if (entryValue != null) {
+                // We have no possibly matching entries and we found a matched entry
+                if (resultEntries.isEmpty()) return entryValue
+
+                // We don't need to process next entries but we need to handle parent entries
+                return rewriteFunctionAppAsIte(entryValue, args, resultEntries)
+            }
+            return null
+        } else {
+            // Args are not values, entry args are values -> args are definitely not in current entry
+            for ((entryArgs, entryValue) in entries) {
+                resultEntries.add(entryArgs to varSubstitution.apply(entryValue))
+            }
+            return null
+        }
+    }
+
+    private fun <T : KSort> ResolvedFunctionUninterpretedEntry<T>.tryResolveArgs(
+        varSubstitution: KExprSubstitutor,
+        args: List<KExpr<*>>,
+        resultEntries: MutableList<Pair<List<KExpr<*>>, KExpr<T>>>
+    ): KExpr<T>? {
+        for (entry in reversedEntries.asReversed()) {
+            val entryArgs = entry.first.map { varSubstitution.apply(it) }
+            val entryValue = varSubstitution.apply(entry.second)
+
+            if (entryArgs == args) {
+                // We have no possibly matching entries and we found a matched entry
+                if (resultEntries.isEmpty()) return entryValue
+
+                // We don't need to process next entries but we need to handle parent entries
+                return rewriteFunctionAppAsIte(entryValue, args, resultEntries)
+            }
+
+            resultEntries.add(entryArgs to entryValue)
+        }
+        return null
+    }
+
+    private class ResolvedFunctionInterpretation<T : KSort>(
+        val interpretation: KModel.KFuncInterp<T>,
+        val rootEntry: ResolvedFunctionEntry<T>
+    )
+
+    private sealed interface ResolvedFunctionEntry<T : KSort> {
+        fun addUninterpretedEntry(args: List<KExpr<*>>, value: KExpr<T>): ResolvedFunctionEntry<T> =
+            ResolvedFunctionUninterpretedEntry(arrayListOf(args to value), this)
+
+        fun addValueEntry(args: List<KExpr<*>>, value: KExpr<T>): ResolvedFunctionEntry<T> =
+            ResolvedFunctionValuesEntry(hashMapOf(args to value), this)
+    }
+
+    private class ResolvedFunctionUninterpretedEntry<T : KSort>(
+        val reversedEntries: MutableList<Pair<List<KExpr<*>>, KExpr<T>>>,
+        val next: ResolvedFunctionEntry<T>
+    ) : ResolvedFunctionEntry<T>{
+        override fun addUninterpretedEntry(args: List<KExpr<*>>, value: KExpr<T>): ResolvedFunctionEntry<T> {
+            reversedEntries.add(args to value)
+            return this
+        }
+    }
+
+    private class ResolvedFunctionValuesEntry<T : KSort>(
+        val entries: MutableMap<List<KExpr<*>>, KExpr<T>>,
+        val next: ResolvedFunctionEntry<T>
+    ) : ResolvedFunctionEntry<T> {
+        override fun addValueEntry(args: List<KExpr<*>>, value: KExpr<T>): ResolvedFunctionEntry<T> {
+            entries[args] = value
+            return this
+        }
+    }
+
+    private class ResolvedFunctionDefaultEntry<T : KSort>(
+        val expr: KExpr<T>?
+    ) : ResolvedFunctionEntry<T>
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/model/KModelImpl.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/model/KModelImpl.kt
@@ -19,13 +19,16 @@ open class KModelImpl(
     override val uninterpretedSorts: Set<KUninterpretedSort>
         get() = uninterpretedSortsUniverses.keys
 
+    private val evaluatorWithModelCompletion by lazy { KModelEvaluator(ctx, this, isComplete = true) }
+    private val evaluatorWithoutModelCompletion by lazy { KModelEvaluator(ctx, this, isComplete = false) }
+
     override fun <T : KSort> eval(
         expr: KExpr<T>,
         isComplete: Boolean
     ): KExpr<T> {
         ctx.ensureContextMatch(expr)
 
-        val evaluator = KModelEvaluator(ctx, this, isComplete)
+        val evaluator = if (isComplete) evaluatorWithModelCompletion else evaluatorWithoutModelCompletion
         return evaluator.apply(expr)
     }
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/utils/ArithUtils.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/utils/ArithUtils.kt
@@ -44,6 +44,24 @@ object ArithUtils {
             else -> decl.value.toBigInteger()
         }
 
+    /**
+     * BigInteger doesn't support mod operation with negative modulus.
+     * We use the mod operation with absolute values and then manually
+     * recover the result depending on the arguments signs.
+     * */
+    fun modWithNegativeNumbers(a: BigInteger, b: BigInteger): BigInteger {
+        val aAbs = a.abs()
+        val bAbs = b.abs()
+        val u = aAbs.mod(bAbs)
+        return when {
+            u == BigInteger.ZERO -> BigInteger.ZERO
+            a >= BigInteger.ZERO && b >= BigInteger.ZERO -> u
+            a < BigInteger.ZERO && b >= BigInteger.ZERO -> -u + b
+            a >= BigInteger.ZERO && b < BigInteger.ZERO -> u + b
+            else -> -u
+        }
+    }
+
     class RealValue private constructor(
         numerator: BigInteger,
         denominator: BigInteger

--- a/ksmt-core/src/test/kotlin/org/ksmt/ArraySimplifyTest.kt
+++ b/ksmt-core/src/test/kotlin/org/ksmt/ArraySimplifyTest.kt
@@ -1,0 +1,51 @@
+package org.ksmt
+
+import org.ksmt.expr.KExpr
+import org.ksmt.sort.KArraySort
+import org.ksmt.sort.KIntSort
+import kotlin.test.Test
+
+
+class ArraySimplifyTest: ExpressionSimplifyTest() {
+
+    @Test
+    fun testArraySelect() = runTest({ mkArraySort(intSort, intSort) }) { sort, runner ->
+        generateArray(sort, GENERATED_ARRAY_SIZE) { array, indices ->
+            for (index in indices) {
+                runner.check(
+                    unsimplifiedExpr = mkArraySelectNoSimplify(array, index),
+                    simplifiedExpr = mkArraySelect(array, index),
+                    printArgs = { "$index | $array" }
+                )
+            }
+        }
+    }
+
+    private inline fun KContext.generateArray(
+        sort: KArraySort<KIntSort, KIntSort>,
+        size: Int,
+        analyze: (KExpr<KArraySort<KIntSort, KIntSort>>, List<KExpr<KIntSort>>) -> Unit
+    ) {
+        val indices = arrayListOf<KExpr<KIntSort>>()
+        var array = mkConst("array", sort)
+
+        for (i in 0 until size) {
+            val index = when {
+                random.nextDouble() < UNINTERPRETED_INDEX_PROBABILITY -> mkFreshConst("idx", intSort)
+                random.nextDouble() < DUPLICATE_INDEX_PROBABILITY -> mkIntNum(i / 2)
+                else -> mkIntNum(i)
+            }
+
+            array = mkArrayStoreNoSimplify(array, index, mkIntNum(i))
+            indices.add(index)
+
+            analyze(array, indices)
+        }
+    }
+
+    companion object {
+        private const val GENERATED_ARRAY_SIZE = 100
+        private const val UNINTERPRETED_INDEX_PROBABILITY = 0.1
+        private const val DUPLICATE_INDEX_PROBABILITY = 0.1
+    }
+}

--- a/ksmt-core/src/test/kotlin/org/ksmt/ArraySimplifyTest.kt
+++ b/ksmt-core/src/test/kotlin/org/ksmt/ArraySimplifyTest.kt
@@ -1,7 +1,7 @@
 package org.ksmt
 
 import org.ksmt.expr.KExpr
-import org.ksmt.sort.KArraySort
+import org.ksmt.sort.KArraySortBase
 import org.ksmt.sort.KIntSort
 import kotlin.test.Test
 
@@ -10,8 +10,12 @@ class ArraySimplifyTest: ExpressionSimplifyTest() {
 
     @Test
     fun testArraySelect() = runTest({ mkArraySort(intSort, intSort) }) { sort, runner ->
-        generateArray(sort, GENERATED_ARRAY_SIZE) { array, indices ->
-            for (index in indices) {
+        generateArray(
+            sort,
+            GENERATED_ARRAY_SIZE,
+            { a, (i), v -> mkArrayStoreNoSimplify(a, i, v) }
+        ) { array, indices ->
+            for ((index) in indices) {
                 runner.check(
                     unsimplifiedExpr = mkArraySelectNoSimplify(array, index),
                     simplifiedExpr = mkArraySelect(array, index),
@@ -21,23 +25,81 @@ class ArraySimplifyTest: ExpressionSimplifyTest() {
         }
     }
 
-    private inline fun KContext.generateArray(
-        sort: KArraySort<KIntSort, KIntSort>,
+    @Test
+    fun testArray2Select() = runTest({ mkArraySort(intSort, intSort, intSort) }) { sort, runner ->
+        generateArray(
+            sort,
+            GENERATED_ARRAY_SIZE,
+            { a, (i0, i1), v -> mkArrayStoreNoSimplify(a, i0, i1, v) }
+        ) { array, indices ->
+            for ((i0, i1) in indices) {
+                runner.check(
+                    unsimplifiedExpr = mkArraySelectNoSimplify(array, i0, i1),
+                    simplifiedExpr = mkArraySelect(array, i0, i1),
+                    printArgs = { "$i0, $i1 | $array" }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testArray3Select() = runTest({ mkArraySort(intSort, intSort, intSort, intSort) }) { sort, runner ->
+        generateArray(
+            sort,
+            GENERATED_ARRAY_SIZE,
+            { a, (i0, i1, i2), v -> mkArrayStoreNoSimplify(a, i0, i1, i2, v) }
+        ) { array, indices ->
+            for ((i0, i1, i2) in indices) {
+                runner.check(
+                    unsimplifiedExpr = mkArraySelectNoSimplify(array, i0, i1, i2),
+                    simplifiedExpr = mkArraySelect(array, i0, i1, i2),
+                    printArgs = { "$i0, $i1, $i2 | $array" }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testArrayNSelect() = runTest({ mkArrayNSort(List(5) { intSort }, intSort) }) { sort, runner ->
+        generateArray(
+            sort,
+            GENERATED_ARRAY_SIZE,
+            { a, idx, v -> mkArrayNStoreNoSimplify(a, idx, v) }
+        ) { array, indices ->
+            for (idx in indices) {
+                runner.check(
+                    unsimplifiedExpr = mkArrayNSelectNoSimplify(array, idx),
+                    simplifiedExpr = mkArrayNSelect(array, idx),
+                    printArgs = { "$idx | $array" }
+                )
+            }
+        }
+    }
+
+    private inline fun <A : KArraySortBase<KIntSort>> KContext.generateArray(
+        sort: A,
         size: Int,
-        analyze: (KExpr<KArraySort<KIntSort, KIntSort>>, List<KExpr<KIntSort>>) -> Unit
+        mkStore: KContext.(KExpr<A>, List<KExpr<KIntSort>>, KExpr<KIntSort>) -> KExpr<A>,
+        analyze: (KExpr<A>, List<List<KExpr<KIntSort>>>) -> Unit
     ) {
-        val indices = arrayListOf<KExpr<KIntSort>>()
-        var array = mkConst("array", sort)
+        val indices = arrayListOf<List<KExpr<KIntSort>>>()
+        var array: KExpr<A> = mkConst("array", sort)
 
         for (i in 0 until size) {
-            val index = when {
-                random.nextDouble() < UNINTERPRETED_INDEX_PROBABILITY -> mkFreshConst("idx", intSort)
-                random.nextDouble() < DUPLICATE_INDEX_PROBABILITY -> mkIntNum(i / 2)
-                else -> mkIntNum(i)
+            val storeIndices = List(sort.domainSorts.size) { idx ->
+                when {
+                    random.nextDouble() < UNINTERPRETED_INDEX_PROBABILITY ->
+                        mkFreshConst("idx", intSort)
+
+                    random.nextDouble() < DUPLICATE_INDEX_PROBABILITY ->
+                        mkIntNum(random.nextInt(0, i / 2 + 1))
+
+                    else -> mkIntNum(i + idx)
+                }
             }
 
-            array = mkArrayStoreNoSimplify(array, index, mkIntNum(i))
-            indices.add(index)
+            array = mkStore(array, storeIndices, mkIntNum(i))
+            indices.add(storeIndices)
 
             analyze(array, indices)
         }
@@ -46,6 +108,6 @@ class ArraySimplifyTest: ExpressionSimplifyTest() {
     companion object {
         private const val GENERATED_ARRAY_SIZE = 100
         private const val UNINTERPRETED_INDEX_PROBABILITY = 0.1
-        private const val DUPLICATE_INDEX_PROBABILITY = 0.1
+        private const val DUPLICATE_INDEX_PROBABILITY = 0.2
     }
 }

--- a/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesModel.kt
+++ b/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesModel.kt
@@ -66,8 +66,14 @@ class KYicesModel(
         knownUninterpretedSortValues[sort]?.values?.toHashSet() ?: hashSetOf()
     }
 
+    private val evaluatorWithModelCompletion by lazy { KModelEvaluator(ctx, this, isComplete = true) }
+    private val evaluatorWithoutModelCompletion by lazy { KModelEvaluator(ctx, this, isComplete = false) }
+
     override fun <T : KSort> eval(expr: KExpr<T>, isComplete: Boolean): KExpr<T> {
-        return KModelEvaluator(ctx, this, isComplete).apply(expr)
+        ctx.ensureContextMatch(expr)
+
+        val evaluator = if (isComplete) evaluatorWithModelCompletion else evaluatorWithoutModelCompletion
+        return evaluator.apply(expr)
     }
 
     private fun getValue(yval: YVal, sort: KSort): KExpr<*> = with(ctx) {


### PR DESCRIPTION
Keep information about interpreted array store indices to achieve constant lookups during array select simplification.

### Changes in arrays processing
* Use `array store` indices information in simplifiers.
* Use similar approach with `interpreted values` analysis in `KModelEvaluator` to speedup function interpreteation argument lookups.
* Array simplification tests. 
* Fix array indices inequality checks. For now, we treat indices as distinct if ANY index is distinct.

### Misc
* Fix bug with integer mod evaluation in case of negative modulus.


### Cache memory usage
Array store memory usage analysis with different indices patterns.
We consider arrays with an `int` indices and `int` values (as in `ArraySimplifyTest`).
Memory usage includes all memory used by `array store`, it indices, value, caches and all memory used by the `KContext`, to store all expression related objects. 
In the table below, all memory usage data is provided as `bytes/single array store expression`.

We analyze memory usage for the following scenarios:
* `no-cache` --- cache is not enabled and doesn't use any additional memory.
* `cache/average` --- cache is enabled. Some indices are not interpreted values. In our experiments the rate of uninterpreted indices is about 10% (as in `ArraySimplifyTest`).
* `cache/interpreted` --- cache is enabled. All indices are interpreted values. In this scenario we explore the maximal cache memory usage. 

| Array dimensions |	no-cache	| cache/average | cache/interpreted |
| ----- | ----- | ----- | ----- |
| **Array 1** |			
| memory, bytes |	198	|  225	| 481 |
| overhead		| | 1.14	| 2.43 |		
| **Array 2** |			
| memory, bytes	| 206	| 260	| 774 |
| overhead		| | 1.26	| 3.75  |	
| **Array 3** |			
| memory, bytes |	206 | 285 |  1060 |
| overhead	| |	1.38	|  5.14 |

Since memory usage overhead can become huge in some scenarios, we provide an option to override `KContext.mkArrayStore` and disable caching for some arrays.
