### PR TITLE
Uninterpreted sort values

### DIFF
--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaModel.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaModel.kt
@@ -4,6 +4,7 @@ import org.ksmt.KContext
 import org.ksmt.decl.KDecl
 import org.ksmt.decl.KFuncDecl
 import org.ksmt.expr.KExpr
+import org.ksmt.expr.KUninterpretedSortValue
 import org.ksmt.solver.KModel
 import org.ksmt.solver.KSolverUnsupportedFeatureException
 import org.ksmt.solver.bitwuzla.bindings.BitwuzlaNativeException
@@ -46,9 +47,9 @@ open class KBitwuzlaModel(
     override val uninterpretedSorts: Set<KUninterpretedSort>
         get() = uninterpretedSortDependency.keys
 
-    private val uninterpretedSortsUniverses = hashMapOf<KUninterpretedSort, Set<KExpr<KUninterpretedSort>>>()
+    private val uninterpretedSortsUniverses = hashMapOf<KUninterpretedSort, Set<KUninterpretedSortValue>>()
 
-    override fun uninterpretedSortUniverse(sort: KUninterpretedSort): Set<KExpr<KUninterpretedSort>>? =
+    override fun uninterpretedSortUniverse(sort: KUninterpretedSort): Set<KUninterpretedSortValue>? =
         uninterpretedSortsUniverses.getOrPut(sort) {
             ctx.ensureContextMatch(sort)
 

--- a/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaUninterpretedSortValueContext.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/org/ksmt/solver/bitwuzla/KBitwuzlaUninterpretedSortValueContext.kt
@@ -1,20 +1,21 @@
 package org.ksmt.solver.bitwuzla
 
 import org.ksmt.KContext
-import org.ksmt.expr.KBitVecValue
+import org.ksmt.expr.KBitVec32Value
 import org.ksmt.expr.KExpr
+import org.ksmt.expr.KUninterpretedSortValue
 import org.ksmt.sort.KUninterpretedSort
 
 class KBitwuzlaUninterpretedSortValueContext(private val ctx: KContext) {
-    private val sortsUniverses = hashMapOf<KUninterpretedSort, MutableMap<KExpr<*>, KExpr<KUninterpretedSort>>>()
+    private val sortsUniverses = hashMapOf<KUninterpretedSort, MutableMap<KExpr<*>, KUninterpretedSortValue>>()
 
-    fun mkValue(sort: KUninterpretedSort, value: KBitVecValue<*>): KExpr<KUninterpretedSort> {
+    fun mkValue(sort: KUninterpretedSort, value: KBitVec32Value): KUninterpretedSortValue {
         val sortUniverse = sortsUniverses.getOrPut(sort) { hashMapOf() }
         return sortUniverse.getOrPut(value) {
-            ctx.mkFreshConst("value!${sortUniverse.size}", sort)
+            ctx.mkUninterpretedSortValue(sort, value.intValue)
         }
     }
 
-    fun currentSortUniverse(sort: KUninterpretedSort): Set<KExpr<KUninterpretedSort>> =
+    fun currentSortUniverse(sort: KUninterpretedSort): Set<KUninterpretedSortValue> =
         sortsUniverses[sort]?.map { it.value }?.toSet() ?: emptySet()
 }

--- a/ksmt-core/build.gradle.kts
+++ b/ksmt-core/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 }
 
 dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5")
+
     testImplementation(project(":ksmt-z3"))
     testImplementation("org.junit.jupiter", "junit-jupiter-params", "5.8.2")
 }

--- a/ksmt-core/build.gradle.kts
+++ b/ksmt-core/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5")
-
     testImplementation(project(":ksmt-z3"))
     testImplementation("org.junit.jupiter", "junit-jupiter-params", "5.8.2")
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
@@ -1036,7 +1036,7 @@ open class KContext(
     ): KArrayStore<D, R> = arrayStoreCache.createIfContextActive {
         ensureContextMatch(array, index, value)
         KArrayStore(this, array, index, value)
-    }.also { it.analyzeStore() }.cast()
+    }.analyzeIfSimplificationEnabled().cast()
 
     open fun <D0 : KSort, D1 : KSort, R : KSort> mkArrayStoreNoSimplifyNoAnalyze(
         array: KExpr<KArray2Sort<D0, D1, R>>,
@@ -1046,7 +1046,7 @@ open class KContext(
     ): KArray2Store<D0, D1, R> = array2StoreCache.createIfContextActive {
         ensureContextMatch(array, index0, index1, value)
         KArray2Store(this, array, index0, index1, value)
-    }.also { it.analyzeStore() }.cast()
+    }.analyzeIfSimplificationEnabled().cast()
 
     open fun <D0 : KSort, D1 : KSort, D2 : KSort, R : KSort> mkArrayStoreNoSimplifyNoAnalyze(
         array: KExpr<KArray3Sort<D0, D1, D2, R>>,
@@ -1057,7 +1057,7 @@ open class KContext(
     ): KArray3Store<D0, D1, D2, R> = array3StoreCache.createIfContextActive {
         ensureContextMatch(array, index0, index1, index2, value)
         KArray3Store(this, array, index0, index1, index2, value)
-    }.also { it.analyzeStore() }.cast()
+    }.analyzeIfSimplificationEnabled().cast()
 
     open fun <R : KSort> mkArrayNStoreNoSimplifyNoAnalyze(
         array: KExpr<KArrayNSort<R>>,
@@ -1068,7 +1068,19 @@ open class KContext(
         ensureContextMatch(array, value)
 
         KArrayNStore(this, array, indices.uncheckedCast(), value)
-    }.also { it.analyzeStore() }.cast()
+    }.analyzeIfSimplificationEnabled().cast()
+
+    private fun <S : KArrayStoreBase<*, *>> S.analyzeIfSimplificationEnabled(): S {
+        /**
+         * Analyze store indices only when simplification is enabled since
+         * we don't expect any benefit from the analyzed stores
+         * if we don't use simplifications.
+         * */
+        if (simplificationMode == SIMPLIFY) {
+            analyzeStore()
+        }
+        return this
+    }
 
     private fun <S : KArrayStoreBase<*, *>> S.analyzeIfSimplificationEnabled(): S {
         /**

--- a/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
@@ -1084,18 +1084,6 @@ open class KContext(
         return this
     }
 
-    private fun <S : KArrayStoreBase<*, *>> S.analyzeIfSimplificationEnabled(): S {
-        /**
-         * Analyze store indices only when simplification is enabled since
-         * we don't expect any benefit from the analyzed stores
-         * if we don't use simplifications.
-         * */
-        if (simplificationMode == SIMPLIFY) {
-            analyzeStore()
-        }
-        return this
-    }
-
     private val arraySelectCache = mkAstInterner<KArraySelect<out KSort, out KSort>>()
     private val array2SelectCache = mkAstInterner<KArray2Select<out KSort, out KSort, out KSort>>()
     private val array3SelectCache = mkAstInterner<KArray3Select<out KSort, out KSort, out KSort, out KSort>>()

--- a/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
@@ -1036,7 +1036,7 @@ open class KContext(
     ): KArrayStore<D, R> = arrayStoreCache.createIfContextActive {
         ensureContextMatch(array, index, value)
         KArrayStore(this, array, index, value)
-    }.analyzeIfSimplificationEnabled().cast()
+    }.cast()
 
     open fun <D0 : KSort, D1 : KSort, R : KSort> mkArrayStoreNoSimplifyNoAnalyze(
         array: KExpr<KArray2Sort<D0, D1, R>>,
@@ -1046,7 +1046,7 @@ open class KContext(
     ): KArray2Store<D0, D1, R> = array2StoreCache.createIfContextActive {
         ensureContextMatch(array, index0, index1, value)
         KArray2Store(this, array, index0, index1, value)
-    }.analyzeIfSimplificationEnabled().cast()
+    }.cast()
 
     open fun <D0 : KSort, D1 : KSort, D2 : KSort, R : KSort> mkArrayStoreNoSimplifyNoAnalyze(
         array: KExpr<KArray3Sort<D0, D1, D2, R>>,
@@ -1057,7 +1057,7 @@ open class KContext(
     ): KArray3Store<D0, D1, D2, R> = array3StoreCache.createIfContextActive {
         ensureContextMatch(array, index0, index1, index2, value)
         KArray3Store(this, array, index0, index1, index2, value)
-    }.analyzeIfSimplificationEnabled().cast()
+    }.cast()
 
     open fun <R : KSort> mkArrayNStoreNoSimplifyNoAnalyze(
         array: KExpr<KArrayNSort<R>>,
@@ -1068,7 +1068,7 @@ open class KContext(
         ensureContextMatch(array, value)
 
         KArrayNStore(this, array, indices.uncheckedCast(), value)
-    }.analyzeIfSimplificationEnabled().cast()
+    }.cast()
 
     private fun <S : KArrayStoreBase<*, *>> S.analyzeIfSimplificationEnabled(): S {
         /**

--- a/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/KContext.kt
@@ -1036,7 +1036,7 @@ open class KContext(
     ): KArrayStore<D, R> = arrayStoreCache.createIfContextActive {
         ensureContextMatch(array, index, value)
         KArrayStore(this, array, index, value)
-    }.cast()
+    }.also { it.analyzeStore() }.cast()
 
     open fun <D0 : KSort, D1 : KSort, R : KSort> mkArrayStoreNoSimplifyNoAnalyze(
         array: KExpr<KArray2Sort<D0, D1, R>>,
@@ -1046,7 +1046,7 @@ open class KContext(
     ): KArray2Store<D0, D1, R> = array2StoreCache.createIfContextActive {
         ensureContextMatch(array, index0, index1, value)
         KArray2Store(this, array, index0, index1, value)
-    }.cast()
+    }.also { it.analyzeStore() }.cast()
 
     open fun <D0 : KSort, D1 : KSort, D2 : KSort, R : KSort> mkArrayStoreNoSimplifyNoAnalyze(
         array: KExpr<KArray3Sort<D0, D1, D2, R>>,
@@ -1057,7 +1057,7 @@ open class KContext(
     ): KArray3Store<D0, D1, D2, R> = array3StoreCache.createIfContextActive {
         ensureContextMatch(array, index0, index1, index2, value)
         KArray3Store(this, array, index0, index1, index2, value)
-    }.cast()
+    }.also { it.analyzeStore() }.cast()
 
     open fun <R : KSort> mkArrayNStoreNoSimplifyNoAnalyze(
         array: KExpr<KArrayNSort<R>>,
@@ -1068,7 +1068,7 @@ open class KContext(
         ensureContextMatch(array, value)
 
         KArrayNStore(this, array, indices.uncheckedCast(), value)
-    }.cast()
+    }.also { it.analyzeStore() }.cast()
 
     private fun <S : KArrayStoreBase<*, *>> S.analyzeIfSimplificationEnabled(): S {
         /**

--- a/ksmt-core/src/main/kotlin/org/ksmt/decl/KUninterpretedSortValueDecl.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/decl/KUninterpretedSortValueDecl.kt
@@ -1,0 +1,15 @@
+package org.ksmt.decl
+
+import org.ksmt.KContext
+import org.ksmt.expr.KApp
+import org.ksmt.expr.KExpr
+import org.ksmt.sort.KUninterpretedSort
+
+class KUninterpretedSortValueDecl internal constructor(
+    ctx: KContext,
+    sort: KUninterpretedSort,
+    val valueIdx: Int
+) : KConstDecl<KUninterpretedSort>(ctx, "${sort.name}!val!${valueIdx}", sort) {
+    override fun apply(args: List<KExpr<*>>): KApp<KUninterpretedSort, *> =
+        ctx.mkUninterpretedSortValue(sort, valueIdx)
+}

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/KUninterpretedSortValue.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/KUninterpretedSortValue.kt
@@ -1,0 +1,24 @@
+package org.ksmt.expr
+
+import org.ksmt.KContext
+import org.ksmt.cache.hash
+import org.ksmt.cache.structurallyEqual
+import org.ksmt.decl.KDecl
+import org.ksmt.expr.transformer.KTransformerBase
+import org.ksmt.sort.KUninterpretedSort
+
+class KUninterpretedSortValue internal constructor(
+    ctx: KContext,
+    override val sort: KUninterpretedSort,
+    val valueIdx: Int
+) : KInterpretedValue<KUninterpretedSort>(ctx) {
+    override val decl: KDecl<KUninterpretedSort>
+        get() = ctx.mkUninterpretedSortValueDecl(sort, valueIdx)
+
+    override fun accept(transformer: KTransformerBase): KExpr<KUninterpretedSort> =
+        transformer.transform(this)
+
+    override fun internHashCode(): Int = hash(sort, valueIdx)
+
+    override fun internEquals(other: Any): Boolean = structurallyEqual(other, { sort }, { valueIdx })
+}

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/KExprSimplifier.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/rewrite/simplify/KExprSimplifier.kt
@@ -12,6 +12,7 @@ import org.ksmt.expr.KEqExpr
 import org.ksmt.expr.KExistentialQuantifier
 import org.ksmt.expr.KExpr
 import org.ksmt.expr.KInterpretedValue
+import org.ksmt.expr.KUninterpretedSortValue
 import org.ksmt.expr.KUniversalQuantifier
 import org.ksmt.expr.rewrite.KExprUninterpretedDeclCollector
 import org.ksmt.expr.transformer.KNonRecursiveTransformerBase
@@ -252,12 +253,22 @@ open class KExprSimplifier(override val ctx: KContext) :
     open fun simplifyEqUninterpreted(
         lhs: KExpr<KUninterpretedSort>,
         rhs: KExpr<KUninterpretedSort>
-    ): KExpr<KBoolSort> = withExpressionsOrdered(lhs, rhs, ctx::mkEqNoSimplify)
+    ): KExpr<KBoolSort> = with(ctx) {
+        if (lhs is KUninterpretedSortValue && rhs is KUninterpretedSortValue) {
+            return (lhs == rhs).expr
+        }
+        return withExpressionsOrdered(lhs, rhs, ctx::mkEqNoSimplify)
+    }
 
     open fun areDefinitelyDistinctUninterpreted(
         lhs: KExpr<KUninterpretedSort>,
         rhs: KExpr<KUninterpretedSort>
-    ): Boolean = false
+    ): Boolean {
+        if (lhs is KUninterpretedSortValue && rhs is KUninterpretedSortValue) {
+            return lhs != rhs
+        }
+        return false
+    }
 
 
     private class RewriteFrame(

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/transformer/KTransformer.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/transformer/KTransformer.kt
@@ -147,6 +147,7 @@ import org.ksmt.expr.KToIntRealExpr
 import org.ksmt.expr.KToRealIntExpr
 import org.ksmt.expr.KTrue
 import org.ksmt.expr.KUnaryMinusArithExpr
+import org.ksmt.expr.KUninterpretedSortValue
 import org.ksmt.expr.KUniversalQuantifier
 import org.ksmt.expr.KXorExpr
 import org.ksmt.sort.KArithSort
@@ -171,6 +172,7 @@ import org.ksmt.sort.KFpSort
 import org.ksmt.sort.KIntSort
 import org.ksmt.sort.KRealSort
 import org.ksmt.sort.KSort
+import org.ksmt.sort.KUninterpretedSort
 
 
 interface KTransformer : KTransformerBase {
@@ -430,4 +432,7 @@ interface KTransformer : KTransformerBase {
             transformExpr(mkUniversalQuantifier(body, expr.bounds))
         }
     }
+
+    // uninterpreted sort value
+    override fun transform(expr: KUninterpretedSortValue): KExpr<KUninterpretedSort> = transformValue(expr)
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/expr/transformer/KTransformerBase.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/expr/transformer/KTransformerBase.kt
@@ -138,6 +138,7 @@ import org.ksmt.expr.KToIntRealExpr
 import org.ksmt.expr.KToRealIntExpr
 import org.ksmt.expr.KTrue
 import org.ksmt.expr.KUnaryMinusArithExpr
+import org.ksmt.expr.KUninterpretedSortValue
 import org.ksmt.expr.KUniversalQuantifier
 import org.ksmt.expr.KXorExpr
 import org.ksmt.sort.KArithSort
@@ -162,6 +163,7 @@ import org.ksmt.sort.KFpSort
 import org.ksmt.sort.KIntSort
 import org.ksmt.sort.KRealSort
 import org.ksmt.sort.KSort
+import org.ksmt.sort.KUninterpretedSort
 
 
 interface KTransformerBase {
@@ -342,4 +344,7 @@ interface KTransformerBase {
     // quantifier transformers
     fun transform(expr: KExistentialQuantifier): KExpr<KBoolSort>
     fun transform(expr: KUniversalQuantifier): KExpr<KBoolSort>
+
+    // uninterpreted sort value
+    fun transform(expr: KUninterpretedSortValue): KExpr<KUninterpretedSort>
 }

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/KModel.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/KModel.kt
@@ -3,6 +3,7 @@ package org.ksmt.solver
 import org.ksmt.decl.KDecl
 import org.ksmt.decl.KFuncDecl
 import org.ksmt.expr.KExpr
+import org.ksmt.expr.KUninterpretedSortValue
 import org.ksmt.sort.KSort
 import org.ksmt.sort.KUninterpretedSort
 
@@ -18,7 +19,7 @@ interface KModel {
     /**
      * Set of possible values of an Uninterpreted Sort.
      * */
-    fun uninterpretedSortUniverse(sort: KUninterpretedSort): Set<KExpr<KUninterpretedSort>>?
+    fun uninterpretedSortUniverse(sort: KUninterpretedSort): Set<KUninterpretedSortValue>?
 
     fun detach(): KModel
 

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/model/KModelEvaluator.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/model/KModelEvaluator.kt
@@ -179,37 +179,7 @@ open class KModelEvaluator(
         return quantifierBuilder(evaluatedBody)
     }
 
-    override fun simplifyEqUninterpreted(
-        lhs: KExpr<KUninterpretedSort>,
-        rhs: KExpr<KUninterpretedSort>
-    ): KExpr<KBoolSort> = with(ctx) {
-        if (isUninterpretedValue(lhs.sort, lhs) && isUninterpretedValue(lhs.sort, rhs)) {
-            return (lhs == rhs).expr
-        }
-        super.simplifyEqUninterpreted(lhs, rhs)
-    }
-
-    override fun areDefinitelyDistinctUninterpreted(
-        lhs: KExpr<KUninterpretedSort>,
-        rhs: KExpr<KUninterpretedSort>
-    ): Boolean {
-        if (isUninterpretedValue(lhs.sort, lhs) && isUninterpretedValue(lhs.sort, rhs)) {
-            return lhs != rhs
-        }
-        return super.areDefinitelyDistinctUninterpreted(lhs, rhs)
-    }
-
-    private fun isUninterpretedValue(sort: KUninterpretedSort, expr: KExpr<KUninterpretedSort>): Boolean {
-        val sortUniverse = model.uninterpretedSortUniverse(sort) ?: return false
-        return expr in sortUniverse
-    }
-
-    private fun isValueInModel(expr: KExpr<*>): Boolean {
-        if (expr is KInterpretedValue<*>) return true
-        val sort = expr.sort
-        if (sort is KUninterpretedSort && isUninterpretedValue(sort, expr.uncheckedCast())) return true
-        return false
-    }
+    private fun isValueInModel(expr: KExpr<*>): Boolean = expr is KInterpretedValue<*>
 
     @Suppress("USELESS_CAST") // Exhaustive when
     private fun <A : KArraySortBase<R>, R : KSort> evalArrayInterpretation(
@@ -272,15 +242,6 @@ open class KModelEvaluator(
             if (interpretation == null && !isComplete) {
                 // return without cache
                 return ctx.mkApp(decl, args)
-            }
-
-            // Check if expr is an uninterpreted value of a sort
-            if (interpretation == null && decl.sort is KUninterpretedSort) {
-                val universe = model.uninterpretedSortUniverse(decl.sort) ?: emptySet()
-                val expr = ctx.mkApp(decl, args)
-                if (expr.uncheckedCast() in universe) {
-                    return expr
-                }
             }
 
             // isComplete = true, return and cache

--- a/ksmt-core/src/main/kotlin/org/ksmt/solver/model/KModelImpl.kt
+++ b/ksmt-core/src/main/kotlin/org/ksmt/solver/model/KModelImpl.kt
@@ -3,6 +3,7 @@ package org.ksmt.solver.model
 import org.ksmt.KContext
 import org.ksmt.decl.KDecl
 import org.ksmt.expr.KExpr
+import org.ksmt.expr.KUninterpretedSortValue
 import org.ksmt.solver.KModel
 import org.ksmt.sort.KSort
 import org.ksmt.sort.KUninterpretedSort
@@ -11,7 +12,7 @@ import org.ksmt.utils.uncheckedCast
 open class KModelImpl(
     val ctx: KContext,
     private val interpretations: Map<KDecl<*>, KModel.KFuncInterp<*>>,
-    private val uninterpretedSortsUniverses: Map<KUninterpretedSort, Set<KExpr<KUninterpretedSort>>>
+    private val uninterpretedSortsUniverses: Map<KUninterpretedSort, Set<KUninterpretedSortValue>>
 ) : KModel {
     override val declarations: Set<KDecl<*>>
         get() = interpretations.keys
@@ -40,7 +41,7 @@ open class KModelImpl(
         return interpretations[decl]?.uncheckedCast()
     }
 
-    override fun uninterpretedSortUniverse(sort: KUninterpretedSort): Set<KExpr<KUninterpretedSort>>? {
+    override fun uninterpretedSortUniverse(sort: KUninterpretedSort): Set<KUninterpretedSortValue>? {
         ctx.ensureContextMatch(sort)
 
         return uninterpretedSortsUniverses[sort]

--- a/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5Context.kt
+++ b/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5Context.kt
@@ -145,10 +145,6 @@ class KCvc5Context(
     fun saveConvertedExpr(expr: Term, converted: KExpr<*>): KExpr<*> =
         convertAst(currentScopeExpressions, cvc5Expressions, expr) { converted }
 
-    fun saveConvertedExprWithoutReverseCache(expr: Term, converted: KExpr<*>) {
-        cvc5Expressions.putIfAbsent(expr, converted)
-    }
-
     // sort
     fun findInternalizedSort(sort: KSort): Sort? = sorts[sort]
 

--- a/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5Context.kt
+++ b/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5Context.kt
@@ -265,7 +265,10 @@ class KCvc5Context(
 
     private fun assertPendingUninterpretedValueConstraints(solver: Solver) {
         while (currentValueConstraintsLevel < uninterpretedSortValueDescriptors.size) {
-            assertUninterpretedSortValueConstraint(solver, uninterpretedSortValueDescriptors[currentValueConstraintsLevel])
+            assertUninterpretedSortValueConstraint(
+                solver,
+                uninterpretedSortValueDescriptors[currentValueConstraintsLevel]
+            )
             currentValueConstraintsLevel++
         }
     }

--- a/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5Context.kt
+++ b/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5Context.kt
@@ -194,6 +194,17 @@ class KCvc5Context(
     }
 
 
+    @Suppress("ForbiddenComment")
+    /**
+     * Uninterpreted sort values distinct constraints management.
+     *
+     * 1. save/register uninterpreted value.
+     * See [KUninterpretedSortValue] internalization for the details.
+     * 2. Assert distinct constraints ([assertPendingAxioms]) that may be introduced during internalization.
+     * Currently, we assert constraints for all the values we have ever internalized.
+     *
+     * todo: precise uninterpreted sort values tracking
+     * */
     private data class UninterpretedSortValueDescriptor(
         val value: KUninterpretedSortValue,
         val nativeUniqueValueDescriptor: Term,

--- a/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5Context.kt
+++ b/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5Context.kt
@@ -81,7 +81,10 @@ class KCvc5Context(
      */
     fun uninterpretedSorts(): List<Set<KUninterpretedSort>> = uninterpretedSorts
 
-    fun addDeclaration(decl: KDecl<*>) { currentLevelDeclarations += decl }
+    fun addDeclaration(decl: KDecl<*>) {
+        currentLevelDeclarations += decl
+        uninterpretedSortCollector.collect(decl)
+    }
 
     /**
      * declarations of active push-levels

--- a/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5Context.kt
+++ b/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5Context.kt
@@ -1,5 +1,6 @@
 package org.ksmt.solver.cvc5
 
+import io.github.cvc5.Kind
 import io.github.cvc5.Solver
 import io.github.cvc5.Sort
 import io.github.cvc5.Term
@@ -11,6 +12,7 @@ import org.ksmt.expr.KExistentialQuantifier
 import org.ksmt.expr.KExpr
 import org.ksmt.expr.KFunctionApp
 import org.ksmt.expr.KFunctionAsArray
+import org.ksmt.expr.KUninterpretedSortValue
 import org.ksmt.expr.KUniversalQuantifier
 import org.ksmt.expr.rewrite.KExprUninterpretedDeclCollector
 import org.ksmt.expr.transformer.KNonRecursiveTransformer
@@ -97,12 +99,16 @@ class KCvc5Context(
         declarations.add(currentLevelDeclarations)
         currentLevelUninterpretedSorts = hashSetOf()
         uninterpretedSorts.add(currentLevelUninterpretedSorts)
+
+        pushAssertionLevel()
     }
 
     fun pop(n: UInt) {
         repeat(n.toInt()) {
             declarations.removeLast()
             uninterpretedSorts.removeLast()
+
+            popAssertionLevel()
         }
 
         currentLevelDeclarations = declarations.last()
@@ -138,6 +144,10 @@ class KCvc5Context(
 
     fun saveConvertedExpr(expr: Term, converted: KExpr<*>): KExpr<*> =
         convertAst(currentScopeExpressions, cvc5Expressions, expr) { converted }
+
+    fun saveConvertedExprWithoutReverseCache(expr: Term, converted: KExpr<*>) {
+        cvc5Expressions.putIfAbsent(expr, converted)
+    }
 
     // sort
     fun findInternalizedSort(sort: KSort): Sort? = sorts[sort]
@@ -184,6 +194,91 @@ class KCvc5Context(
         return save(key, computeValue())
     }
 
+
+    private data class UninterpretedSortValueDescriptor(
+        val value: KUninterpretedSortValue,
+        val nativeUniqueValueDescriptor: Term,
+        val nativeValueTerm: Term
+    )
+
+    private var currentValueConstraintsLevel = 0
+    private val assertedConstraintLevels = arrayListOf<Int>()
+    private val uninterpretedSortValueDescriptors = arrayListOf<UninterpretedSortValueDescriptor>()
+    private val uninterpretedSortValueInterpreter = hashMapOf<KUninterpretedSort, Term>()
+
+    private val uninterpretedSortValues =
+        hashMapOf<KUninterpretedSort, MutableList<Pair<Term, KUninterpretedSortValue>>>()
+
+    fun saveUninterpretedSortValue(nativeValue: Term, value: KUninterpretedSortValue): Term {
+        val sortValues = uninterpretedSortValues.getOrPut(value.sort) { arrayListOf() }
+        sortValues.add(nativeValue to value)
+        return nativeValue
+    }
+
+    inline fun registerUninterpretedSortValue(
+        value: KUninterpretedSortValue,
+        uniqueValueDescriptorTerm: Term,
+        uninterpretedValueTerm: Term,
+        mkInterpreter: () -> Term
+    ) {
+        val interpreter = getUninterpretedSortValueInterpreter(value.sort)
+        if (interpreter == null) {
+            registerUninterpretedSortValueInterpreter(value.sort, mkInterpreter())
+        }
+
+        registerUninterpretedSortValue(value, uniqueValueDescriptorTerm, uninterpretedValueTerm)
+    }
+
+    fun assertPendingAxioms(solver: Solver) {
+        assertPendingUninterpretedValueConstraints(solver)
+    }
+
+    fun getUninterpretedSortValueInterpreter(sort: KUninterpretedSort): Term? =
+        uninterpretedSortValueInterpreter[sort]
+
+    fun registerUninterpretedSortValueInterpreter(sort: KUninterpretedSort, interpreter: Term) {
+        uninterpretedSortValueInterpreter[sort] = interpreter
+    }
+
+    fun registerUninterpretedSortValue(
+        value: KUninterpretedSortValue,
+        uniqueValueDescriptorTerm: Term,
+        uninterpretedValueTerm: Term
+    ) {
+        uninterpretedSortValueDescriptors += UninterpretedSortValueDescriptor(
+            value = value,
+            nativeUniqueValueDescriptor = uniqueValueDescriptorTerm,
+            nativeValueTerm = uninterpretedValueTerm
+        )
+    }
+
+    fun getRegisteredSortValues(sort: KUninterpretedSort): List<Pair<Term, KUninterpretedSortValue>> =
+        uninterpretedSortValues[sort] ?: emptyList()
+
+    private fun pushAssertionLevel() {
+        assertedConstraintLevels.add(currentValueConstraintsLevel)
+    }
+
+    private fun popAssertionLevel() {
+        currentValueConstraintsLevel = assertedConstraintLevels.removeLast()
+    }
+
+    private fun assertPendingUninterpretedValueConstraints(solver: Solver) {
+        while (currentValueConstraintsLevel < uninterpretedSortValueDescriptors.size) {
+            assertUninterpretedSortValueConstraint(solver, uninterpretedSortValueDescriptors[currentValueConstraintsLevel])
+            currentValueConstraintsLevel++
+        }
+    }
+
+    private fun assertUninterpretedSortValueConstraint(solver: Solver, value: UninterpretedSortValueDescriptor) {
+        val interpreter = uninterpretedSortValueInterpreter[value.value.sort]
+            ?: error("Interpreter was not registered for sort: ${value.value.sort}")
+
+        val constraintLhs = solver.mkTerm(Kind.APPLY_UF, arrayOf(interpreter, value.nativeValueTerm))
+        val constraint = constraintLhs.eqTerm(value.nativeUniqueValueDescriptor)
+
+        solver.assertFormula(constraint)
+    }
 
     private inline fun <K> internalizeAst(
         cache: MutableMap<K, Term>,

--- a/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5ExprInternalizer.kt
+++ b/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5ExprInternalizer.kt
@@ -213,6 +213,8 @@ class KCvc5ExprInternalizer(
 
     override fun <T : KSort> transform(expr: KFunctionApp<T>) = with(expr) {
         transformArray(args) { args: Array<Term> ->
+            cvc5Ctx.addDeclaration(decl)
+
             // args[0] is a function declaration
             val decl = decl.internalizeDecl()
 
@@ -226,6 +228,8 @@ class KCvc5ExprInternalizer(
 
     override fun <T : KSort> transform(expr: KConst<T>) = with(expr) {
         transform {
+            cvc5Ctx.addDeclaration(decl)
+
             decl.internalizeDecl()
         }
     }

--- a/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5ExprInternalizer.kt
+++ b/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5ExprInternalizer.kt
@@ -1120,7 +1120,7 @@ class KCvc5ExprInternalizer(
      * There is no way in cvc5 API to mark uninterpreted constant as value.
      *
      * To overcome this we apply the following scheme:
-     * 1. Internalize value `x` of as sort T as normal constant.
+     * 1. Internalize value `x` of a sort T as normal constant.
      * 2. Associate unique interpreted value `i` with this constant.
      * Currently, we use integer values.
      * 3. Introduce `interpreter` function `F` of type T -> Int.

--- a/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5ExprInternalizer.kt
+++ b/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5ExprInternalizer.kt
@@ -1116,6 +1116,19 @@ class KCvc5ExprInternalizer(
         )
     }
 
+    /**
+     * There is no way in cvc5 API to mark uninterpreted constant as value.
+     *
+     * To overcome this we apply the following scheme:
+     * 1. Internalize value `x` of as sort T as normal constant.
+     * 2. Associate unique interpreted value `i` with this constant.
+     * Currently, we use integer values.
+     * 3. Introduce `interpreter` function `F` of type T -> Int.
+     * We introduce one function for each uninterpreted sort.
+     * 4. Assert expression `(= i (F x))` to the solver.
+     * Since all Int values are known to be distinct, this
+     * assertion forces that all values of T are also distinct.
+     * */
     override fun transform(expr: KUninterpretedSortValue): KExpr<KUninterpretedSort> = with(expr) {
         transform(ctx.mkIntNum(expr.valueIdx)) { intValueExpr: Term ->
             val exprSort = sort.internalizeSort()

--- a/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5Solver.kt
+++ b/ksmt-cvc5/src/main/kotlin/org.ksmt.solver.cvc5/KCvc5Solver.kt
@@ -59,6 +59,8 @@ open class KCvc5Solver(private val ctx: KContext) : KSolver<KCvc5SolverConfigura
 
         val cvc5Expr = with(exprInternalizer) { expr.internalizeExpr() }
         solver.assertFormula(cvc5Expr)
+
+        cvc5Ctx.assertPendingAxioms(solver)
     }
 
     override fun assertAndTrack(expr: KExpr<KBoolSort>, trackVar: KConstDecl<KBoolSort>) {
@@ -125,10 +127,9 @@ open class KCvc5Solver(private val ctx: KContext) : KSolver<KCvc5SolverConfigura
         return KCvc5Model(
             ctx,
             cvc5Ctx,
-            exprConverter,
             exprInternalizer,
-            cvc5Ctx.declarations().flatten().toSet(),
-            cvc5Ctx.uninterpretedSorts().flatten().toSet()
+            cvc5Ctx.declarations().flatMapTo(hashSetOf()) { it },
+            cvc5Ctx.uninterpretedSorts().flatMapTo(hashSetOf()) { it },
         )
     }
 

--- a/ksmt-cvc5/src/test/kotlin/org/ksmt/solver/cvc5/UninterpretedSortValueTest.kt
+++ b/ksmt-cvc5/src/test/kotlin/org/ksmt/solver/cvc5/UninterpretedSortValueTest.kt
@@ -1,0 +1,87 @@
+package org.ksmt.solver.cvc5
+
+import org.ksmt.KContext
+import org.ksmt.expr.KExpr
+import org.ksmt.expr.KUninterpretedSortValue
+import org.ksmt.solver.KSolverStatus
+import org.ksmt.sort.KUninterpretedSort
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class UninterpretedSortValueTest {
+    private val ctx = KContext(simplificationMode = KContext.SimplificationMode.NO_SIMPLIFY)
+    private val solver = KCvc5Solver(ctx)
+
+    @Test
+    fun testUninterpretedSortValueDistinct() = with(ctx) {
+        val sort = mkUninterpretedSort("T")
+        val value0 = mkUninterpretedSortValue(sort, 0)
+        val value1 = mkUninterpretedSortValue(sort, 1)
+
+        solver.push()
+
+        solver.assert(value0 eq value1)
+
+        assertEquals(KSolverStatus.UNSAT, solver.check())
+
+        solver.pop()
+
+        // Internalization skipped
+        solver.assert(value0 eq value1)
+
+        assertEquals(KSolverStatus.UNSAT, solver.check())
+    }
+
+    @Test
+    fun testUninterpretedSortValueModel() = with(ctx) {
+        val sort = mkUninterpretedSort("T")
+        val value0 = mkUninterpretedSortValue(sort, 0)
+        val value1 = mkUninterpretedSortValue(sort, 1)
+
+        val var0 = mkConst("v0", sort)
+        val var1 = mkConst("v1", sort)
+        val var2 = mkConst("v2", sort)
+
+        solver.assert(var0 eq value1)
+        solver.assert(var1 eq value0)
+
+        solver.push()
+
+        solver.assert(var0 eq var1)
+        assertEquals(KSolverStatus.UNSAT, solver.check())
+
+        solver.pop()
+
+        solver.push()
+        checkSatAndValidateModel(var0, var1, var2, value0, value1)
+        solver.pop()
+
+        checkSatAndValidateModel(var0, var1, var2, value0, value1)
+    }
+
+    private fun KContext.checkSatAndValidateModel(
+        var0: KExpr<KUninterpretedSort>,
+        var1: KExpr<KUninterpretedSort>,
+        var2: KExpr<KUninterpretedSort>,
+        value0: KUninterpretedSortValue,
+        value1: KUninterpretedSortValue,
+    ) {
+        solver.assert(mkDistinct(listOf(var0, var1, var2)))
+        assertEquals(KSolverStatus.SAT, solver.check())
+
+        val model = solver.model()
+
+        val modelValue0 = model.eval(var0, isComplete = false)
+        val modelValue1 = model.eval(var1, isComplete = false)
+        val modelValue2 = model.eval(var2, isComplete = false)
+
+        assertEquals(value0, modelValue1)
+        assertEquals(value1, modelValue0)
+
+        assertTrue(modelValue2 is KUninterpretedSortValue)
+        assertNotEquals(value0, modelValue2)
+        assertNotEquals(value1, modelValue2)
+    }
+}

--- a/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstDeserializer.kt
+++ b/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstDeserializer.kt
@@ -76,7 +76,15 @@ class AstDeserializer(
         val name = readString()
         val argSorts = readAstArray()
         val sort = readSort()
-        mkFuncDecl(name, sort, argSorts as List<KSort>)
+
+        /**
+         * Generate fresh decl because:
+         * 1. Declaration is not in the [serializationCtx] --> declaration was not previously serialized.
+         * 2. Was not serialized --> was not registered in our [KContext].
+         * 3. Was not registered --> may clash with some another registered declaration.
+         * 4. Use fresh declaration to ensure that this decl will never overlap with some other registered decl.
+         * */
+        mkFreshFuncDecl(name, sort, argSorts as List<KSort>)
     }
 
     private fun AbstractBuffer.deserializeSort(sortKind: SortKind): KSort = with(serializationCtx.ctx) {

--- a/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstDeserializer.kt
+++ b/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstDeserializer.kt
@@ -13,6 +13,7 @@ import org.ksmt.sort.KBoolSort
 import org.ksmt.sort.KFpSort
 import org.ksmt.sort.KIntSort
 import org.ksmt.sort.KSort
+import org.ksmt.sort.KUninterpretedSort
 import org.ksmt.utils.uncheckedCast
 
 @OptIn(ExperimentalUnsignedTypes::class)
@@ -274,6 +275,9 @@ class AstDeserializer(
             ExprKind.UniversalQuantifier -> {
                 val bounds = readAstArray()
                 mkUniversalQuantifier(readExpr(), bounds as List<KDecl<*>>)
+            }
+            ExprKind.UninterpretedSortValue -> {
+                mkUninterpretedSortValue(readSort() as KUninterpretedSort, readInt())
             }
         }
     }

--- a/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstSerializer.kt
+++ b/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/AstSerializer.kt
@@ -144,6 +144,7 @@ import org.ksmt.expr.KToIntRealExpr
 import org.ksmt.expr.KToRealIntExpr
 import org.ksmt.expr.KTrue
 import org.ksmt.expr.KUnaryMinusArithExpr
+import org.ksmt.expr.KUninterpretedSortValue
 import org.ksmt.expr.KUniversalQuantifier
 import org.ksmt.expr.KXorExpr
 import org.ksmt.solver.util.KExprIntInternalizerBase
@@ -1124,6 +1125,16 @@ class AstSerializer(
             writeExpr {
                 writeAst(sortIdx)
                 writeAst(funcIdx)
+            }
+        }
+    }
+
+    override fun transform(expr: KUninterpretedSortValue) = with(expr) {
+        transform {
+            val sortIdx = sort.serializeSort()
+            writeExpr {
+                writeAst(sortIdx)
+                writeAst(valueIdx)
             }
         }
     }

--- a/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/ExprKind.kt
+++ b/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/ExprKind.kt
@@ -140,4 +140,5 @@ enum class ExprKind {
     RealNumExpr,
     ExistentialQuantifier,
     UniversalQuantifier,
+    UninterpretedSortValue,
 }

--- a/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/ExprKindMapper.kt
+++ b/ksmt-runner/src/main/kotlin/org/ksmt/runner/serializer/ExprKindMapper.kt
@@ -138,6 +138,7 @@ import org.ksmt.expr.KToIntRealExpr
 import org.ksmt.expr.KToRealIntExpr
 import org.ksmt.expr.KTrue
 import org.ksmt.expr.KUnaryMinusArithExpr
+import org.ksmt.expr.KUninterpretedSortValue
 import org.ksmt.expr.KUniversalQuantifier
 import org.ksmt.expr.KXorExpr
 import org.ksmt.expr.transformer.KTransformerBase
@@ -163,6 +164,7 @@ import org.ksmt.sort.KFpSort
 import org.ksmt.sort.KIntSort
 import org.ksmt.sort.KRealSort
 import org.ksmt.sort.KSort
+import org.ksmt.sort.KUninterpretedSort
 
 class ExprKindMapper: KTransformerBase {
 
@@ -630,4 +632,6 @@ class ExprKindMapper: KTransformerBase {
 
     override fun transform(expr: KUniversalQuantifier): KExpr<KBoolSort> = expr.kind(ExprKind.UniversalQuantifier)
 
+    override fun transform(expr: KUninterpretedSortValue): KExpr<KUninterpretedSort> =
+        expr.kind(ExprKind.UninterpretedSortValue)
 }

--- a/ksmt-runner/src/main/kotlin/org/ksmt/solver/runner/KSolverRunnerExecutor.kt
+++ b/ksmt-runner/src/main/kotlin/org/ksmt/solver/runner/KSolverRunnerExecutor.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.withTimeout
 import org.ksmt.decl.KConstDecl
 import org.ksmt.decl.KDecl
 import org.ksmt.expr.KExpr
+import org.ksmt.expr.KUninterpretedSortValue
 import org.ksmt.runner.core.KsmtWorkerSession
 import org.ksmt.runner.generated.models.AssertAndTrackParams
 import org.ksmt.runner.generated.models.AssertParams
@@ -125,7 +126,7 @@ class KSolverRunnerExecutor(
         }
         val uninterpretedSortUniverse = result.uninterpretedSortUniverse.associateBy(
             { entry -> entry.sort as KUninterpretedSort },
-            { entry -> entry.universe.mapTo(hashSetOf()) { it as KExpr<KUninterpretedSort> } }
+            { entry -> entry.universe.mapTo(hashSetOf()) { it as KUninterpretedSortValue } }
         )
         return KModelImpl(worker.astSerializationCtx.ctx, interpretations.toMap(), uninterpretedSortUniverse)
     }

--- a/ksmt-test/src/main/kotlin/org/ksmt/test/TestWorkerProcess.kt
+++ b/ksmt-test/src/main/kotlin/org/ksmt/test/TestWorkerProcess.kt
@@ -84,7 +84,7 @@ class TestWorkerProcess : ChildProcessBase<TestProtocolModel>() {
     }
 
     private fun convertAssertions(nativeAssertions: List<Long>): List<KExpr<KBoolSort>> {
-        val converter = KZ3ExprConverter(ctx, KZ3Context(z3Ctx))
+        val converter = KZ3ExprConverter(ctx, KZ3Context(ctx, z3Ctx))
         return with(converter) { nativeAssertions.map { it.convertExpr() } }
     }
 
@@ -144,7 +144,7 @@ class TestWorkerProcess : ChildProcessBase<TestProtocolModel>() {
                 setParameters(params)
             }
         }
-        solvers.add(solver to KZ3Context(z3Ctx))
+        solvers.add(solver to KZ3Context(ctx, z3Ctx))
         return solvers.lastIndex
     }
 

--- a/ksmt-test/src/main/kotlin/org/ksmt/test/TestWorkerProcess.kt
+++ b/ksmt-test/src/main/kotlin/org/ksmt/test/TestWorkerProcess.kt
@@ -44,7 +44,12 @@ class TestWorkerProcess : ChildProcessBase<TestProtocolModel>() {
     private val z3Ctx: Context
         get() = workerZ3Ctx ?: error("Solver is not initialized")
 
-    private val solvers = mutableListOf<Pair<Solver, KZ3Context>>()
+    private class OracleSolver(
+        val solver: Solver,
+        val solverCtx: KZ3Context
+    )
+
+    private val solvers = mutableListOf<OracleSolver>()
     private val nativeAsts = mutableListOf<AST>()
     private val equalityChecks = mutableMapOf<Int, MutableList<EqualityCheck>>()
     private val equalityCheckAssumptions = mutableMapOf<Int, MutableList<Expr<BoolSort>>>()
@@ -144,17 +149,17 @@ class TestWorkerProcess : ChildProcessBase<TestProtocolModel>() {
                 setParameters(params)
             }
         }
-        solvers.add(solver to KZ3Context(ctx, z3Ctx))
+        solvers.add(OracleSolver(solver, KZ3Context(ctx, z3Ctx)))
         return solvers.lastIndex
     }
 
     private fun assert(solver: Int, expr: Long) {
         @Suppress("UNCHECKED_CAST")
-        solvers[solver].first.add(z3Ctx.wrapAST(expr) as Expr<BoolSort>)
+        solvers[solver].solver.add(z3Ctx.wrapAST(expr) as Expr<BoolSort>)
     }
 
     private fun check(solver: Int): KSolverStatus {
-        return solvers[solver].first.check().processCheckResult()
+        return solvers[solver].solver.check().processCheckResult()
     }
 
     private fun exprToString(expr: Long): String {
@@ -162,7 +167,7 @@ class TestWorkerProcess : ChildProcessBase<TestProtocolModel>() {
     }
 
     private fun getReasonUnknown(solver: Int): String {
-        return solvers[solver].first.reasonUnknown
+        return solvers[solver].solver.reasonUnknown
     }
 
     private fun addEqualityCheck(solver: Int, actual: KExpr<*>, expected: Long) {
@@ -181,16 +186,16 @@ class TestWorkerProcess : ChildProcessBase<TestProtocolModel>() {
     private fun checkEqualities(solver: Int): KSolverStatus = with(z3Ctx) {
         val checks = equalityChecks[solver] ?: emptyList()
         val equalityBindings = checks.map { mkNot(mkEq(it.actual, it.expected)) }
-        equalityCheckAssumptions[solver]?.forEach { solvers[solver].first.add(it) }
-        solvers[solver].second.assertPendingAxioms(solvers[solver].first)
-        solvers[solver].first.add(mkOr(*equalityBindings.toTypedArray()))
+        equalityCheckAssumptions[solver]?.forEach { solvers[solver].solver.add(it) }
+        solvers[solver].solverCtx.assertPendingAxioms(solvers[solver].solver)
+        solvers[solver].solver.add(mkOr(*equalityBindings.toTypedArray()))
         return check(solver)
     }
 
     private fun findFirstFailedEquality(solver: Int): Int? = with(z3Ctx){
-        val solverInstance = solvers[solver].first
-        equalityCheckAssumptions[solver]?.forEach { solvers[solver].first.add(it) }
-        solvers[solver].second.assertPendingAxioms(solvers[solver].first)
+        val solverInstance = solvers[solver].solver
+        equalityCheckAssumptions[solver]?.forEach { solvers[solver].solver.add(it) }
+        solvers[solver].solverCtx.assertPendingAxioms(solvers[solver].solver)
         val checks = equalityChecks[solver] ?: emptyList()
         for ((idx, check) in checks.withIndex()) {
             solverInstance.push()
@@ -217,7 +222,7 @@ class TestWorkerProcess : ChildProcessBase<TestProtocolModel>() {
     }
 
     private fun internalize(solver: Int, expr: KExpr<*>): Expr<*> {
-        val internCtx = solvers[solver].second
+        val internCtx = solvers[solver].solverCtx
         val internalizer = KZ3ExprInternalizer(ctx, internCtx)
         val internalized = with(internalizer) { expr.internalizeExpr() }
         return z3Ctx.wrapAST(internalized) as Expr<*>

--- a/ksmt-test/src/main/kotlin/org/ksmt/test/TestWorkerProcess.kt
+++ b/ksmt-test/src/main/kotlin/org/ksmt/test/TestWorkerProcess.kt
@@ -44,7 +44,7 @@ class TestWorkerProcess : ChildProcessBase<TestProtocolModel>() {
     private val z3Ctx: Context
         get() = workerZ3Ctx ?: error("Solver is not initialized")
 
-    private val solvers = mutableListOf<Solver>()
+    private val solvers = mutableListOf<Pair<Solver, KZ3Context>>()
     private val nativeAsts = mutableListOf<AST>()
     private val equalityChecks = mutableMapOf<Int, MutableList<EqualityCheck>>()
     private val equalityCheckAssumptions = mutableMapOf<Int, MutableList<Expr<BoolSort>>>()
@@ -144,17 +144,17 @@ class TestWorkerProcess : ChildProcessBase<TestProtocolModel>() {
                 setParameters(params)
             }
         }
-        solvers.add(solver)
+        solvers.add(solver to KZ3Context(z3Ctx))
         return solvers.lastIndex
     }
 
     private fun assert(solver: Int, expr: Long) {
         @Suppress("UNCHECKED_CAST")
-        solvers[solver].add(z3Ctx.wrapAST(expr) as Expr<BoolSort>)
+        solvers[solver].first.add(z3Ctx.wrapAST(expr) as Expr<BoolSort>)
     }
 
     private fun check(solver: Int): KSolverStatus {
-        return solvers[solver].check().processCheckResult()
+        return solvers[solver].first.check().processCheckResult()
     }
 
     private fun exprToString(expr: Long): String {
@@ -162,18 +162,18 @@ class TestWorkerProcess : ChildProcessBase<TestProtocolModel>() {
     }
 
     private fun getReasonUnknown(solver: Int): String {
-        return solvers[solver].reasonUnknown
+        return solvers[solver].first.reasonUnknown
     }
 
     private fun addEqualityCheck(solver: Int, actual: KExpr<*>, expected: Long) {
-        val actualExpr = internalize(actual)
+        val actualExpr = internalize(solver, actual)
         val expectedExpr = z3Ctx.wrapAST(expected) as Expr<*>
         val checks = equalityChecks.getOrPut(solver) { mutableListOf() }
         checks += EqualityCheck(actual = actualExpr, expected = expectedExpr)
     }
 
     private fun addEqualityCheckAssumption(solver: Int, assumption: KExpr<*>) {
-        val assumptionExpr = internalize(assumption)
+        val assumptionExpr = internalize(solver, assumption)
         val assumptions = equalityCheckAssumptions.getOrPut(solver) { mutableListOf() }
         assumptions.add(assumptionExpr.uncheckedCast())
     }
@@ -181,14 +181,16 @@ class TestWorkerProcess : ChildProcessBase<TestProtocolModel>() {
     private fun checkEqualities(solver: Int): KSolverStatus = with(z3Ctx) {
         val checks = equalityChecks[solver] ?: emptyList()
         val equalityBindings = checks.map { mkNot(mkEq(it.actual, it.expected)) }
-        equalityCheckAssumptions[solver]?.forEach { solvers[solver].add(it) }
-        solvers[solver].add(mkOr(*equalityBindings.toTypedArray()))
+        equalityCheckAssumptions[solver]?.forEach { solvers[solver].first.add(it) }
+        solvers[solver].second.assertPendingAxioms(solvers[solver].first)
+        solvers[solver].first.add(mkOr(*equalityBindings.toTypedArray()))
         return check(solver)
     }
 
     private fun findFirstFailedEquality(solver: Int): Int? = with(z3Ctx){
-        val solverInstance = solvers[solver]
-        equalityCheckAssumptions[solver]?.forEach { solvers[solver].add(it) }
+        val solverInstance = solvers[solver].first
+        equalityCheckAssumptions[solver]?.forEach { solvers[solver].first.add(it) }
+        solvers[solver].second.assertPendingAxioms(solvers[solver].first)
         val checks = equalityChecks[solver] ?: emptyList()
         for ((idx, check) in checks.withIndex()) {
             solverInstance.push()
@@ -214,8 +216,9 @@ class TestWorkerProcess : ChildProcessBase<TestProtocolModel>() {
         null -> KSolverStatus.UNKNOWN
     }
 
-    private fun internalize(expr: KExpr<*>): Expr<*> {
-        val internalizer = KZ3ExprInternalizer(ctx, KZ3Context(z3Ctx))
+    private fun internalize(solver: Int, expr: KExpr<*>): Expr<*> {
+        val internCtx = solvers[solver].second
+        val internalizer = KZ3ExprInternalizer(ctx, internCtx)
         val internalized = with(internalizer) { expr.internalizeExpr() }
         return z3Ctx.wrapAST(internalized) as Expr<*>
     }

--- a/ksmt-test/src/test/kotlin/org/ksmt/test/MultiIndexedArrayTest.kt
+++ b/ksmt-test/src/test/kotlin/org/ksmt/test/MultiIndexedArrayTest.kt
@@ -334,8 +334,8 @@ class MultiIndexedArrayTest {
     }
 
     private fun <T : KSort> KContext.internalizeAndConvertZ3(nativeCtx: Context, expr: KExpr<T>): KExpr<T> {
-        val z3InternCtx = KZ3Context(nativeCtx)
-        val z3ConvertCtx = KZ3Context(nativeCtx)
+        val z3InternCtx = KZ3Context(this, nativeCtx)
+        val z3ConvertCtx = KZ3Context(this, nativeCtx)
 
         val internalized = with(KZ3ExprInternalizer(this, z3InternCtx)) {
             expr.internalizeExpr()

--- a/ksmt-test/src/test/kotlin/org/ksmt/test/UninterpretedSortValuesTest.kt
+++ b/ksmt-test/src/test/kotlin/org/ksmt/test/UninterpretedSortValuesTest.kt
@@ -1,0 +1,264 @@
+package org.ksmt.test
+
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.ksmt.KContext
+import org.ksmt.expr.KExpr
+import org.ksmt.solver.KModel
+import org.ksmt.solver.KSolver
+import org.ksmt.solver.KSolverConfiguration
+import org.ksmt.solver.KSolverStatus
+import org.ksmt.solver.bitwuzla.KBitwuzlaSolver
+import org.ksmt.solver.cvc5.KCvc5Solver
+import org.ksmt.solver.runner.KSolverRunnerManager
+import org.ksmt.solver.yices.KYicesSolver
+import org.ksmt.solver.z3.KZ3Solver
+import org.ksmt.sort.KArraySort
+import org.ksmt.sort.KBoolSort
+import org.ksmt.sort.KSort
+import org.ksmt.sort.KUninterpretedSort
+import org.ksmt.utils.uncheckedCast
+import kotlin.random.Random
+import kotlin.random.nextInt
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+@EnabledIfEnvironmentVariable(
+    named = "runUninterpretedSortValuesTest",
+    matches = "true",
+    disabledReason = "Not suitable for usual CI runs"
+)
+class UninterpretedSortValuesTest {
+
+    @Test
+    fun test(): Unit = with(KContext(simplificationMode = KContext.SimplificationMode.NO_SIMPLIFY)) {
+        val testData = generateTestData()
+        KSolverRunnerManager(workerPoolSize = 3).use { solverManager ->
+            solverManager.createSolver(this, KZ3Solver::class).use { oracleSover ->
+                val z3Results = solverManager.testSolver(this, KZ3Solver::class, testData)
+                validateResults(oracleSover, z3Results)
+
+                val yicesResults = solverManager.testSolver(this, KYicesSolver::class, testData)
+                validateResults(oracleSover, yicesResults)
+
+                val bitwuzlaResults = solverManager.testSolver(this, KBitwuzlaSolver::class, testData)
+                validateResults(oracleSover, bitwuzlaResults)
+
+                val cvcResults = solverManager.testSolver(this, KCvc5Solver::class, testData)
+                validateResults(oracleSover, cvcResults)
+            }
+        }
+    }
+
+    private fun <C : KSolverConfiguration> KSolverRunnerManager.testSolver(
+        ctx: KContext,
+        solverType: KClass<out KSolver<C>>,
+        data: List<KExpr<KBoolSort>>
+    ) = createSolver(ctx, solverType).use { solver ->
+        val results = arrayListOf<TestResult>()
+
+        for ((i, sample) in data.withIndex()) {
+            solver.push()
+
+            solver.assert(sample)
+            val status = solver.check(SINGLE_CHECK_TIMEOUT)
+
+            val model = if (status == KSolverStatus.SAT) solver.model() else null
+
+            results += TestResult(
+                testId = i,
+                solverName = solverType.simpleName!!,
+                testSample = sample,
+                status = status,
+                model = model?.detach()
+            )
+
+            solver.pop()
+        }
+
+        results
+    }
+
+    private fun KContext.validateResults(oracle: KSolver<*>, results: List<TestResult>) {
+        validateResultStatus(results)
+
+        for (res in results) {
+            if (res.model == null) continue
+            validateModel(oracle, res, res.model)
+        }
+    }
+
+    private fun KContext.validateModel(oracle: KSolver<*>, result: TestResult, model: KModel) {
+        val actualValue = model.eval(result.testSample, isComplete = false)
+        if (actualValue == trueExpr) return
+
+        oracle.push()
+
+        model.uninterpretedSorts.forEach { sort ->
+            val universe = model.uninterpretedSortUniverse(sort)
+            if (!universe.isNullOrEmpty()) {
+                val x = mkFreshConst("x", sort)
+                val constraint = mkOr(universe.map { x eq it })
+
+                oracle.assert(mkUniversalQuantifier(constraint, listOf(x.decl)))
+            }
+        }
+
+        oracle.assert(actualValue neq trueExpr)
+
+        val status = oracle.check()
+        assertEquals(KSolverStatus.UNSAT, status)
+
+        oracle.pop()
+    }
+
+    private fun validateResultStatus(results: List<TestResult>) {
+        val statuses = results
+            .groupBy({ it.testId }, { it.status })
+            .mapValues { (_, status) -> status.filterNot { it == KSolverStatus.UNKNOWN }.toSet() }
+
+        assertTrue(statuses.all { it.value.size <= 1 })
+    }
+
+    private fun KContext.generateTestData(): List<KExpr<KBoolSort>> {
+        val sorts = (0 until NUMBER_OF_UNINTERPRETED_SORTS).map {
+            mkUninterpretedSort("T${it}")
+        }
+        val generationContext = GenerationContext(this, sorts)
+        return (0 until TEST_SET_SIZE).map {
+            generationContext.generate()
+        }
+    }
+
+    private class GenerationContext(
+        val ctx: KContext,
+        val sorts: List<KUninterpretedSort>
+    ) {
+        private val random = Random(RANDOM_SEED)
+
+        private val sortMapOperations = sorts.associateWith { s1 ->
+            sorts.associateWith { s2 ->
+                ctx.mkFuncDecl("${s1}_${s2}", s2, listOf(s1))
+            }
+        }
+
+        private val basicExpressions = sorts.associateWithTo(hashMapOf<KSort, MutableList<KExpr<*>>>()) {
+            arrayListOf(ctx.mkFreshConst("x", it))
+        }
+
+        private val expressions = hashMapOf<KSort, MutableList<KExpr<*>>>()
+
+        private fun newExpr() = when (random.nextDouble()) {
+            in 0.0..0.1 -> newArray()
+            in 0.1..0.3 -> newVar()
+            else -> newValue()
+        }
+
+        private fun newArray() = with(ctx) {
+            val sort = mkArraySort(sorts.random(random), sorts.random(random))
+            mkFreshConst("array", sort)
+        }
+
+        private fun newVar() = with(ctx) {
+            mkFreshConst("v", sorts.random(random))
+        }
+
+        private fun newValue() = with(ctx) {
+            mkUninterpretedSortValue(sorts.random(random), random.nextInt(USORT_VALUE_RANGE))
+        }
+
+        private fun findExpr(sort: KSort): KExpr<KSort> {
+            if (random.nextDouble() > 0.5) {
+                newExpr().also {
+                    basicExpressions.getOrPut(it.sort) { arrayListOf() }.add(it)
+                }
+            }
+
+            val expressionSet = when (random.nextDouble()) {
+                in 0.0..0.4 -> basicExpressions
+                else -> expressions
+            }
+
+            val variants = expressionSet.getOrPut(sort) {
+                arrayListOf(ctx.mkFreshConst("stub", sort))
+            }
+
+            return variants.random(random).uncheckedCast()
+        }
+
+        fun generate(): KExpr<KBoolSort> {
+            expressions.clear()
+
+            val first = generateDeepExpr()
+            val second = generateDeepExpr()
+
+            val transformer = sortMapOperations[first.sort]?.get(second.sort)
+                ?: error("Unexpected sorts: ${first.sort}, ${second.sort}")
+            val firstAsSecond = transformer.apply(listOf(first))
+
+            return ctx.mkEq(firstAsSecond, second.uncheckedCast())
+        }
+
+        private fun generateDeepExpr(): KExpr<KSort> {
+            var current = findExpr(sorts.random(random))
+            repeat(EXPRESSION_DEPTH) {
+                current = if (current.sort is KArraySort<*, *>) {
+                    generateArrayOperation(current.uncheckedCast())
+                } else {
+                    generateOperation(current)
+                }
+                expressions.getOrPut(current.sort) { arrayListOf() }.add(current)
+            }
+
+            val sort = current.sort
+            if (sort is KArraySort<*, *>) {
+                current = ctx.mkArraySelect(current.uncheckedCast(), findExpr(sort.domain))
+            }
+
+            return current
+        }
+
+        private fun generateArrayOperation(expr: KExpr<KArraySort<KSort, KSort>>): KExpr<KSort> = with(ctx) {
+            when (random.nextDouble()) {
+                in 0.0..0.3 -> mkArraySelect(expr, findExpr(expr.sort.domain))
+                else -> mkArrayStore(expr, findExpr(expr.sort.domain), findExpr(expr.sort.range)).uncheckedCast()
+            }
+        }
+
+        private fun generateOperation(expr: KExpr<KSort>): KExpr<KSort> = with(ctx) {
+            when (random.nextDouble()) {
+                in 0.0..0.5 -> {
+                    val otherSort = sorts.random(random)
+                    val transformer = sortMapOperations[expr.sort]?.get(otherSort)
+                        ?: error("Unexpected expr sort: ${expr.sort}")
+                    transformer.apply(listOf(expr)).uncheckedCast()
+                }
+
+                else -> {
+                    val sort = mkArraySort(expr.sort, sorts.random(random))
+                    val array: KExpr<KArraySort<KSort, KSort>> = findExpr(sort).uncheckedCast()
+                    mkArrayStore(array, expr, findExpr(sort.range)).uncheckedCast()
+                }
+            }
+        }
+    }
+
+    private data class TestResult(
+        val testId: Int,
+        val solverName: String,
+        val testSample: KExpr<KBoolSort>,
+        val status: KSolverStatus,
+        val model: KModel?
+    )
+
+    companion object {
+        private const val NUMBER_OF_UNINTERPRETED_SORTS = 3
+        private const val RANDOM_SEED = 42
+        private const val EXPRESSION_DEPTH = 30
+        private const val TEST_SET_SIZE = 500
+        private val USORT_VALUE_RANGE = 0 until 25
+        private val SINGLE_CHECK_TIMEOUT = 1.seconds
+    }
+}

--- a/ksmt-test/src/test/kotlin/org/ksmt/test/benchmarks/BenchmarksBasedTest.kt
+++ b/ksmt-test/src/test/kotlin/org/ksmt/test/benchmarks/BenchmarksBasedTest.kt
@@ -126,7 +126,7 @@ abstract class BenchmarksBasedTest {
                 val evaluatedAssertions = ksmtAssertions.map { model.eval(it, isComplete = true) }
 
                 val cardinalityConstraints = model.uninterpretedSorts.mapNotNull { sort ->
-                    model.uninterpretedSortUniverse(sort)?.let { universe ->
+                    model.uninterpretedSortUniverse(sort)?.takeIf { it.isNotEmpty() }?.let { universe ->
                         with(ctx) {
                             val x = mkFreshConst("x", sort)
                             val variants = mkOr(universe.map { x eq it })

--- a/ksmt-test/src/test/kotlin/org/ksmt/test/benchmarks/BenchmarksBasedTest.kt
+++ b/ksmt-test/src/test/kotlin/org/ksmt/test/benchmarks/BenchmarksBasedTest.kt
@@ -130,8 +130,7 @@ abstract class BenchmarksBasedTest {
                         with(ctx) {
                             val x = mkFreshConst("x", sort)
                             val variants = mkOr(universe.map { x eq it })
-                            val uniqueness = mkDistinct(universe.toList())
-                            mkUniversalQuantifier(variants and uniqueness, listOf(x.decl))
+                            mkUniversalQuantifier(variants, listOf(x.decl))
                         }
                     }
                 }

--- a/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesContext.kt
+++ b/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesContext.kt
@@ -309,7 +309,7 @@ open class KYicesContext : AutoCloseable {
 
     fun convertUninterpretedSortValueIndex(internalIndex: Int): Int {
         // User provided value index
-        if (internalIndex > UNINTERPRETED_SORT_VALUE_SHIFT) {
+        if (internalIndex >= UNINTERPRETED_SORT_VALUE_SHIFT) {
             return internalIndex - UNINTERPRETED_SORT_VALUE_SHIFT
         }
 

--- a/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesContext.kt
+++ b/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesContext.kt
@@ -291,6 +291,8 @@ open class KYicesContext : AutoCloseable {
     fun exists(bounds: YicesTermArray, body: YicesTerm) = mkTerm { Terms.exists(bounds, body) }
     fun forall(bounds: YicesTermArray, body: YicesTerm) = mkTerm { Terms.forall(bounds, body) }
 
+    fun uninterpretedSortConst(sort: YicesSort, idx: Int) = mkTerm { Terms.mkConst(sort, idx) }
+
     fun substitute(term: YicesTerm, substituteFrom: YicesTermArray, substituteTo: YicesTermArray): YicesTerm =
         mkTerm { Terms.subst(term, substituteFrom, substituteTo) }
 

--- a/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesContext.kt
+++ b/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesContext.kt
@@ -10,6 +10,7 @@ import org.ksmt.decl.KDecl
 import org.ksmt.expr.KConst
 import org.ksmt.expr.KExpr
 import org.ksmt.expr.KInterpretedValue
+import org.ksmt.solver.KSolverUnsupportedFeatureException
 import org.ksmt.solver.util.KExprIntInternalizerBase.Companion.NOT_INTERNALIZED
 import org.ksmt.solver.yices.TermUtils.addTerm
 import org.ksmt.solver.yices.TermUtils.andTerm
@@ -293,6 +294,29 @@ open class KYicesContext : AutoCloseable {
 
     fun uninterpretedSortConst(sort: YicesSort, idx: Int) = mkTerm { Terms.mkConst(sort, idx) }
 
+    private var maxValueIndex = 0
+
+    fun uninterpretedSortValueIndex(idx: Int): Int {
+        if (idx !in UNINTERPRETED_SORT_VALUE_INDEX_RANGE) {
+            throw KSolverUnsupportedFeatureException(
+                "Yices solver requires value index to be in range: $UNINTERPRETED_SORT_VALUE_INDEX_RANGE"
+            )
+        }
+
+        maxValueIndex = maxOf(maxValueIndex, idx)
+        return idx + UNINTERPRETED_SORT_VALUE_SHIFT
+    }
+
+    fun convertUninterpretedSortValueIndex(internalIndex: Int): Int {
+        // User provided value index
+        if (internalIndex > UNINTERPRETED_SORT_VALUE_SHIFT) {
+            return internalIndex - UNINTERPRETED_SORT_VALUE_SHIFT
+        }
+
+        // Create a new index that doesn't overlap with any other indices
+        return ++maxValueIndex
+    }
+
     fun substitute(term: YicesTerm, substituteFrom: YicesTermArray, substituteTo: YicesTermArray): YicesTerm =
         mkTerm { Terms.subst(term, substituteFrom, substituteTo) }
 
@@ -320,6 +344,11 @@ open class KYicesContext : AutoCloseable {
                 Yices.setReadyFlag(true)
             }
         }
+
+        private const val UNINTERPRETED_SORT_VALUE_SHIFT = (1 shl 30) - 1
+
+        internal val UNINTERPRETED_SORT_VALUE_INDEX_RANGE =
+            0 until UNINTERPRETED_SORT_VALUE_SHIFT
 
         internal fun <K> mkTermCache() = Object2IntOpenHashMap<K>().apply {
             defaultReturnValue(NOT_INTERNALIZED)

--- a/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesContext.kt
+++ b/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesContext.kt
@@ -296,6 +296,14 @@ open class KYicesContext : AutoCloseable {
 
     private var maxValueIndex = 0
 
+    /**
+     * Yices can produce different values with the same index.
+     * This situation happens if we create a value with index I (e.g. 2)
+     * and Yices generates a value in the model with index I.
+     * To overcome this, we shift our indices by some very huge value.
+     * Since Yices generates values with a small indices (e.g. 0, 1, 2, ...)
+     * this trick solves the issue.
+     * */
     fun uninterpretedSortValueIndex(idx: Int): Int {
         if (idx !in UNINTERPRETED_SORT_VALUE_INDEX_RANGE) {
             throw KSolverUnsupportedFeatureException(

--- a/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesExprConverter.kt
+++ b/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesExprConverter.kt
@@ -26,6 +26,7 @@ import org.ksmt.sort.KBvSort
 import org.ksmt.sort.KIntSort
 import org.ksmt.sort.KRealSort
 import org.ksmt.sort.KSort
+import org.ksmt.sort.KUninterpretedSort
 import org.ksmt.utils.BvUtils.bvMaxValueUnsigned
 import org.ksmt.utils.BvUtils.bvZero
 import org.ksmt.utils.uncheckedCast
@@ -133,6 +134,13 @@ open class KYicesExprConverter(
                 check(convertedDecl is KConstDecl<*>) { "Unexpected declaration $convertedDecl" }
 
                 convertedDecl.apply()
+            }
+
+            Constructor.SCALAR_CONSTANT -> convert {
+                val idx = Terms.scalarConstantIndex(expr)
+                val sort = convertSort(Terms.typeOf(expr))
+
+                mkUninterpretedSortValue(sort as KUninterpretedSort, idx)
             }
 
             else -> error("Not supported term ${Terms.toString(expr)}")

--- a/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesExprConverter.kt
+++ b/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesExprConverter.kt
@@ -138,9 +138,11 @@ open class KYicesExprConverter(
 
             Constructor.SCALAR_CONSTANT -> convert {
                 val idx = Terms.scalarConstantIndex(expr)
+                val valueIdx = yicesCtx.convertUninterpretedSortValueIndex(idx)
+
                 val sort = convertSort(Terms.typeOf(expr))
 
-                mkUninterpretedSortValue(sort as KUninterpretedSort, idx)
+                mkUninterpretedSortValue(sort as KUninterpretedSort, valueIdx)
             }
 
             else -> error("Not supported term ${Terms.toString(expr)}")

--- a/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesExprInternalizer.kt
+++ b/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesExprInternalizer.kt
@@ -933,7 +933,10 @@ open class KYicesExprInternalizer(
 
     override fun transform(expr: KUninterpretedSortValue): KExpr<KUninterpretedSort> = with(expr) {
         transform {
-            yicesCtx.uninterpretedSortConst(sort.internalizeSort(), valueIdx)
+            yicesCtx.uninterpretedSortConst(
+                sort.internalizeSort(),
+                yicesCtx.uninterpretedSortValueIndex(valueIdx)
+            )
         }
     }
 

--- a/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesExprInternalizer.kt
+++ b/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesExprInternalizer.kt
@@ -142,6 +142,7 @@ import org.ksmt.expr.KToIntRealExpr
 import org.ksmt.expr.KToRealIntExpr
 import org.ksmt.expr.KTrue
 import org.ksmt.expr.KUnaryMinusArithExpr
+import org.ksmt.expr.KUninterpretedSortValue
 import org.ksmt.expr.KUniversalQuantifier
 import org.ksmt.expr.KXorExpr
 import org.ksmt.solver.KSolverUnsupportedFeatureException
@@ -168,6 +169,7 @@ import org.ksmt.sort.KFpSort
 import org.ksmt.sort.KIntSort
 import org.ksmt.sort.KRealSort
 import org.ksmt.sort.KSort
+import org.ksmt.sort.KUninterpretedSort
 import java.math.BigInteger
 
 @Suppress("LargeClass")
@@ -926,6 +928,12 @@ open class KYicesExprInternalizer(
     override fun transform(expr: KUniversalQuantifier): KExpr<KBoolSort> = with(expr) {
         internalizeQuantifiedBody(bounds, body) { vars, body ->
             yicesCtx.forall(vars, body)
+        }
+    }
+
+    override fun transform(expr: KUninterpretedSortValue): KExpr<KUninterpretedSort> = with(expr) {
+        transform {
+            yicesCtx.uninterpretedSortConst(sort.internalizeSort(), valueIdx)
         }
     }
 

--- a/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesModel.kt
+++ b/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesModel.kt
@@ -32,6 +32,7 @@ import org.ksmt.utils.uncheckedCast
 class KYicesModel(
     private val model: Model,
     private val ctx: KContext,
+    private val yicesCtx: KYicesContext,
     private val internalizer: KYicesExprInternalizer,
     private val converter: KYicesExprConverter
 ) : KModel, AutoCloseable {
@@ -84,8 +85,10 @@ class KYicesModel(
             is KIntSort -> mkIntNum(model.bigRationalValue(yval))
             is KUninterpretedSort -> {
                 val uninterpretedSortValueId = model.scalarValue(yval)[0]
+                val valueIndex = yicesCtx.convertUninterpretedSortValueIndex(uninterpretedSortValueId)
+
                 val sortValues = knownUninterpretedSortValues.getOrPut(sort) { hashSetOf() }
-                mkUninterpretedSortValue(sort, uninterpretedSortValueId).also {
+                mkUninterpretedSortValue(sort, valueIndex).also {
                     sortValues.add(it)
                 }
             }

--- a/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesSolver.kt
+++ b/ksmt-yices/src/main/kotlin/org/ksmt/solver/yices/KYicesSolver.kt
@@ -122,7 +122,7 @@ class KYicesSolver(private val ctx: KContext) : KSolver<KYicesSolverConfiguratio
         }
         val model = nativeContext.model
 
-        return KYicesModel(model, ctx, exprInternalizer, exprConverter)
+        return KYicesModel(model, ctx, yicesCtx, exprInternalizer, exprConverter)
     }
 
     override fun unsatCore(): List<KExpr<KBoolSort>> = yicesTry {

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/ExpressionUninterpretedValuesTracker.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/ExpressionUninterpretedValuesTracker.kt
@@ -1,0 +1,218 @@
+package org.ksmt.solver.z3
+
+import com.microsoft.z3.Native
+import com.microsoft.z3.Solver
+import com.microsoft.z3.solverAssert
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
+import org.ksmt.KContext
+import org.ksmt.expr.KExpr
+import org.ksmt.expr.KUninterpretedSortValue
+import org.ksmt.expr.transformer.KNonRecursiveTransformer
+import org.ksmt.sort.KSort
+import org.ksmt.sort.KUninterpretedSort
+
+/**
+ * Uninterpreted sort values distinct constraints management.
+ *
+ * 1. save/register uninterpreted value.
+ * See [KUninterpretedSortValue] internalization for the details.
+ * 2. Assert distinct constraints ([assertPendingUninterpretedValueConstraints])
+ * that may be introduced during internalization.
+ * */
+class ExpressionUninterpretedValuesTracker(val ctx: KContext, val z3Ctx: KZ3Context) {
+    private val expressionLevels = Object2IntOpenHashMap<KExpr<*>>().apply {
+        defaultReturnValue(Int.MAX_VALUE) // Level which is greater than any possible level
+    }
+
+    private var currentFrame = ValueTrackerAssertionFrame(
+        ctx, this, expressionLevels,
+        currentLevel = 0,
+        notAssertedConstraintsFromPreviousLevels = 0
+    )
+
+    private val valueTrackerFrames = arrayListOf(currentFrame)
+
+    private val registeredUninterpretedSortValues =
+        hashMapOf<KUninterpretedSortValue, UninterpretedSortValueDescriptor>()
+
+    private inline fun ifTrackingEnabled(body: () -> Unit) {
+        if (registeredUninterpretedSortValues.isEmpty()) return
+        body()
+    }
+
+    fun expressionUse(expr: KExpr<*>) = ifTrackingEnabled {
+        currentFrame.analyzeUsedExpression(expr)
+    }
+
+    fun expressionSave(expr: KExpr<*>) = ifTrackingEnabled {
+        currentFrame.addExpression(expr)
+    }
+
+    fun registerUninterpretedSortValue(
+        value: KUninterpretedSortValue,
+        uniqueValueDescriptorExpr: Long,
+        uninterpretedValueExpr: Long
+    ) {
+        val descriptor = UninterpretedSortValueDescriptor(
+            value = value,
+            nativeUniqueValueDescriptor = uniqueValueDescriptorExpr,
+            nativeValueExpr = uninterpretedValueExpr
+        )
+        if (registeredUninterpretedSortValues.putIfAbsent(value, descriptor) == null) {
+            currentFrame.addRegisteredValueToCurrentLevel(descriptor)
+        }
+    }
+
+    fun pushAssertionLevel() {
+        currentFrame = currentFrame.nextFrame()
+        valueTrackerFrames.add(currentFrame)
+    }
+
+    fun popAssertionLevel() = ifTrackingEnabled {
+        valueTrackerFrames.removeLast()
+        currentFrame = valueTrackerFrames.last()
+
+        currentFrame.cleanupAfterPop()
+    }
+
+    fun assertPendingUninterpretedValueConstraints(solver: Solver) {
+        for (frameIdx in valueTrackerFrames.lastIndex downTo 0) {
+            val frame = valueTrackerFrames[frameIdx]
+
+            while (frame.notAssertedConstraints > 0) {
+                val valueConstraint = frame.assertNextConstraint()
+                assertUninterpretedSortValueConstraint(solver, valueConstraint)
+            }
+
+            if (frame.notAssertedConstraintsFromPreviousLevels == 0) break
+        }
+    }
+
+    private fun assertUninterpretedSortValueConstraint(solver: Solver, value: UninterpretedSortValueDescriptor) {
+        val interpreter = z3Ctx.getUninterpretedSortValueInterpreter(value.value.sort)
+            ?: error("Interpreter was not registered for sort: ${value.value.sort}")
+
+        val constraintLhs = z3Ctx.temporaryAst(
+            Native.mkApp(z3Ctx.nCtx, interpreter, 1, longArrayOf(value.nativeValueExpr))
+        )
+        val constraint = z3Ctx.temporaryAst(
+            Native.mkEq(z3Ctx.nCtx, constraintLhs, value.nativeUniqueValueDescriptor)
+        )
+
+        solver.solverAssert(constraint)
+
+        z3Ctx.releaseTemporaryAst(constraint)
+        z3Ctx.releaseTemporaryAst(constraintLhs)
+    }
+
+    private data class UninterpretedSortValueDescriptor(
+        val value: KUninterpretedSortValue,
+        val nativeUniqueValueDescriptor: Long,
+        val nativeValueExpr: Long
+    )
+
+    private class ValueTrackerAssertionFrame(
+        val ctx: KContext,
+        val tracker: ExpressionUninterpretedValuesTracker,
+        val expressionLevels: Object2IntOpenHashMap<KExpr<*>>,
+        val currentLevel: Int,
+        val notAssertedConstraintsFromPreviousLevels: Int
+    ) {
+        private var initailized = false
+        private var lastAssertedConstraint = 0
+
+        lateinit var currentLevelExpressions: MutableSet<KExpr<*>>
+        lateinit var currentLevelUninterpretedValues: MutableList<UninterpretedSortValueDescriptor>
+        lateinit var currentLevelExprAnalyzer: ExprUninterpretedValuesAnalyzer
+
+        private fun ensureInitialized() {
+            if (initailized) return
+
+            currentLevelExpressions = hashSetOf()
+            currentLevelUninterpretedValues = arrayListOf()
+            currentLevelExprAnalyzer = ExprUninterpretedValuesAnalyzer(ctx, this)
+
+            initailized = true
+        }
+
+        private val numberOfConstraints: Int
+            get() = if (!initailized) 0 else currentLevelUninterpretedValues.size
+
+        val notAssertedConstraints: Int
+            get() = numberOfConstraints - lastAssertedConstraint
+
+        fun nextFrame(): ValueTrackerAssertionFrame {
+            val nextLevelRemainingConstraints = notAssertedConstraintsFromPreviousLevels + notAssertedConstraints
+            return ValueTrackerAssertionFrame(
+                ctx, tracker, expressionLevels,
+                currentLevel = currentLevel + 1,
+                notAssertedConstraintsFromPreviousLevels = nextLevelRemainingConstraints
+            )
+        }
+
+        fun assertNextConstraint(): UninterpretedSortValueDescriptor =
+            currentLevelUninterpretedValues[lastAssertedConstraint++]
+
+        fun cleanupAfterPop() {
+            if (!initailized) return
+
+            currentLevelExprAnalyzer = ExprUninterpretedValuesAnalyzer(ctx, this)
+        }
+
+        fun analyzeUsedExpression(expr: KExpr<*>) {
+            ensureInitialized()
+
+            if (expr in currentLevelExpressions) return
+            currentLevelExprAnalyzer.apply(expr)
+        }
+
+        fun addExpression(expr: KExpr<*>) {
+            ensureInitialized()
+
+            if (currentLevelExpressions.add(expr)) {
+                expressionLevels.put(expr, currentLevel)
+            }
+        }
+
+        fun addRegisteredValueToCurrentLevel(value: KUninterpretedSortValue) {
+            val descriptor = tracker.registeredUninterpretedSortValues[value]
+                ?: error("Value $value was not registered")
+            addRegisteredValueToCurrentLevel(descriptor)
+        }
+
+        fun addRegisteredValueToCurrentLevel(descriptor: UninterpretedSortValueDescriptor) {
+            ensureInitialized()
+
+            currentLevelUninterpretedValues.add(descriptor)
+        }
+
+        fun getFrame(level: Int) = tracker.valueTrackerFrames[level]
+    }
+
+    private class ExprUninterpretedValuesAnalyzer(
+        ctx: KContext,
+        val frame: ValueTrackerAssertionFrame
+    ) : KNonRecursiveTransformer(ctx) {
+        override fun <T : KSort> transformExpr(expr: KExpr<T>): KExpr<T> = with(frame) {
+            if (currentLevelExpressions.add(expr)) {
+                expressionLevels.put(expr, currentLevel)
+            }
+            return super.transformExpr(expr)
+        }
+
+        override fun transform(expr: KUninterpretedSortValue): KExpr<KUninterpretedSort> {
+            frame.addRegisteredValueToCurrentLevel(expr)
+            return super.transform(expr)
+        }
+
+        override fun <T : KSort> exprTransformationRequired(expr: KExpr<T>): Boolean = with(frame) {
+            val frameLevel = expressionLevels.getInt(expr)
+            if (frameLevel < currentLevel) {
+                val levelFrame = getFrame(frameLevel)
+                // If expr is valid on its level we don't need to move it
+                return expr !in levelFrame.currentLevelExpressions
+            }
+            return super.exprTransformationRequired(expr)
+        }
+    }
+}

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Context.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Context.kt
@@ -38,6 +38,7 @@ class KZ3Context(private val ctx: Context) : AutoCloseable {
     private val z3Sorts = Long2ObjectOpenHashMap<KSort>()
     private val z3Decls = Long2ObjectOpenHashMap<KDecl<*>>()
     private val tmpNativeObjects = LongOpenHashSet()
+    private val converterNativeObjects = LongOpenHashSet()
 
     @JvmField
     val nCtx: Long = ctx.nCtx()
@@ -121,6 +122,16 @@ class KZ3Context(private val ctx: Context) : AutoCloseable {
         if (tmpNativeObjects.remove(ast)) {
             decRefUnsafe(nCtx, ast)
         }
+    }
+
+    /**
+     * Save reference to the converter local object.
+     * */
+    fun saveConverterNativeObject(ast: Long): Long {
+        if (converterNativeObjects.add(ast)) {
+            incRefUnsafe(nCtx, ast)
+        }
+        return ast
     }
 
     @Suppress("ForbiddenComment")

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Context.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Context.kt
@@ -11,6 +11,7 @@ import it.unimi.dsi.fastutil.longs.LongOpenHashSet
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap
 import org.ksmt.decl.KDecl
 import org.ksmt.expr.KExpr
+import org.ksmt.expr.KInterpretedValue
 import org.ksmt.expr.KUninterpretedSortValue
 import org.ksmt.solver.util.KExprLongInternalizerBase.Companion.NOT_INTERNALIZED
 import org.ksmt.sort.KSort
@@ -61,6 +62,11 @@ class KZ3Context(private val ctx: Context) : AutoCloseable {
     }
 
     fun saveConvertedExpr(expr: Long, converted: KExpr<*>) {
+        /**
+         * It is not safe to save complex converted expressions
+         * because they may contain model bound variables.
+         * */
+        if (converted !is KInterpretedValue<*>) return
         saveConvertedAst(expr, converted, expressions, z3Expressions)
     }
 

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Context.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Context.kt
@@ -148,7 +148,7 @@ class KZ3Context(private val ctx: Context) : AutoCloseable {
         return decl
     }
 
-    fun saveUninterpretedSortValueInterpreted(decl: Long): Long {
+    fun saveUninterpretedSortValueInterpreter(decl: Long): Long {
         if (uninterpretedSortValueInterpreters.add(decl)) {
             incRefUnsafe(nCtx, decl)
         }

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Context.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Context.kt
@@ -123,6 +123,17 @@ class KZ3Context(private val ctx: Context) : AutoCloseable {
         }
     }
 
+    @Suppress("ForbiddenComment")
+    /**
+     * Uninterpreted sort values distinct constraints management.
+     *
+     * 1. save/register uninterpreted value.
+     * See [KUninterpretedSortValue] internalization for the details.
+     * 2. Assert distinct constraints ([assertPendingAxioms]) that may be introduced during internalization.
+     * Currently, we assert constraints for all the values we have ever internalized.
+     *
+     * todo: precise uninterpreted sort values tracking
+     * */
     private data class UninterpretedSortValueDescriptor(
         val value: KUninterpretedSortValue,
         val nativeUniqueValueDescriptor: Long,

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Context.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Context.kt
@@ -64,10 +64,6 @@ class KZ3Context(private val ctx: Context) : AutoCloseable {
         saveConvertedAst(expr, converted, expressions, z3Expressions)
     }
 
-    fun saveConvertedExprWithoutReverseCache(expr: Long, converted: KExpr<*>) {
-        z3Expressions.putIfAbsent(expr, converted)
-    }
-
     /**
      * Find internalized sort.
      * Returns [NOT_INTERNALIZED] if sort was not found.

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Context.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Context.kt
@@ -11,7 +11,6 @@ import it.unimi.dsi.fastutil.longs.LongOpenHashSet
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap
 import org.ksmt.decl.KDecl
 import org.ksmt.expr.KExpr
-import org.ksmt.expr.KInterpretedValue
 import org.ksmt.expr.KUninterpretedSortValue
 import org.ksmt.solver.util.KExprLongInternalizerBase.Companion.NOT_INTERNALIZED
 import org.ksmt.sort.KSort
@@ -62,11 +61,6 @@ class KZ3Context(private val ctx: Context) : AutoCloseable {
     }
 
     fun saveConvertedExpr(expr: Long, converted: KExpr<*>) {
-        /**
-         * It is not safe to save complex converted expressions
-         * because they may contain model bound variables.
-         * */
-        if (converted !is KInterpretedValue<*>) return
         saveConvertedAst(expr, converted, expressions, z3Expressions)
     }
 

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprConverter.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprConverter.kt
@@ -20,6 +20,7 @@ import org.ksmt.expr.KExpr
 import org.ksmt.expr.KFpRoundingMode
 import org.ksmt.expr.KFpRoundingModeExpr
 import org.ksmt.expr.KIntNumExpr
+import org.ksmt.expr.KInterpretedValue
 import org.ksmt.expr.KRealNumExpr
 import org.ksmt.expr.rewrite.KExprUninterpretedDeclCollector
 import org.ksmt.solver.util.ExprConversionResult
@@ -68,7 +69,13 @@ open class KZ3ExprConverter(
 
     override fun saveConvertedNative(native: Long, converted: KExpr<*>) {
         if (converterLocalCache.putIfAbsent(native, converted) == null) {
-            z3Ctx.saveConvertedExpr(native, converted)
+            /**
+             * It is not safe to save complex converted expressions
+             * because they may contain model bound variables.
+             * */
+            if (converted is KInterpretedValue<*>) {
+                z3Ctx.saveConvertedExpr(native, converted)
+            }
         }
     }
 

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprConverter.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprConverter.kt
@@ -401,6 +401,16 @@ open class KZ3ExprConverter(
         }
     }
 
+    /**
+     * Parameterized function declarations are usually internal
+     * Z3 functions with some additional information.
+     * We trying recognize such parameterized functions
+     * and use this information for conversion purposes.
+     * If the recognition fails, then we treat these declarations
+     * as ordinary uninterpreted functions.
+     *
+     * Currently, we can recognize declarations of an uninterpreted sort values.
+     * */
     private fun tryConvertParametrizedDeclApp(
         expr: Long,
         nativeDecl: Long,

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprConverter.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprConverter.kt
@@ -75,6 +75,8 @@ open class KZ3ExprConverter(
              * */
             if (converted is KInterpretedValue<*>) {
                 z3Ctx.saveConvertedExpr(native, converted)
+            } else {
+                z3Ctx.saveConverterNativeObject(native)
             }
         }
     }

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
@@ -844,7 +844,7 @@ open class KZ3ExprInternalizer(
      * There is no way in Z3 API to mark uninterpreted constant as value.
      *
      * To overcome this we apply the following scheme:
-     * 1. Internalize value `x` of as sort T as normal constant.
+     * 1. Internalize value `x` of a sort T as normal constant.
      * 2. Associate unique interpreted value `i` with this constant.
      * Currently, we use integer values.
      * 3. Introduce `interpreter` function `F` of type T -> Int.

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
@@ -854,7 +854,7 @@ open class KZ3ExprInternalizer(
 
                 z3InternCtx.registerUninterpretedSortValue(expr, intValueExpr, it) {
                     val descriptorSort = ctx.intSort.internalizeSort()
-                    z3InternCtx.saveUninterpretedSortValueInterpreted(
+                    z3InternCtx.saveUninterpretedSortValueInterpreter(
                         Native.mkFreshFuncDecl(nCtx, "interpreter", 1, longArrayOf(nativeSort), descriptorSort)
                     )
                 }

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3ExprInternalizer.kt
@@ -840,6 +840,19 @@ open class KZ3ExprInternalizer(
         transform { Native.mkAsArray(nCtx, function.internalizeDecl()) }
     }
 
+    /**
+     * There is no way in Z3 API to mark uninterpreted constant as value.
+     *
+     * To overcome this we apply the following scheme:
+     * 1. Internalize value `x` of as sort T as normal constant.
+     * 2. Associate unique interpreted value `i` with this constant.
+     * Currently, we use integer values.
+     * 3. Introduce `interpreter` function `F` of type T -> Int.
+     * We introduce one function for each uninterpreted sort.
+     * 4. Assert expression `(= i (F x))` to the solver.
+     * Since all Int values are known to be distinct, this
+     * assertion forces that all values of T are also distinct.
+     * */
     override fun transform(expr: KUninterpretedSortValue): KExpr<KUninterpretedSort> = with(expr) {
         transform(ctx.mkIntNum(expr.valueIdx)) { intValueExpr ->
             val nativeSort = sort.internalizeSort()

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Model.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Model.kt
@@ -34,6 +34,11 @@ open class KZ3Model(
 
     private val functionDeclarations: Set<KDecl<*>> by lazy {
         model.getNativeFuncDecls().convertToSet {
+            /**
+             * In a case of uninterpreted sort values, we introduce
+             * special `interpreter` functions which are internal and
+             * must not appear in a user models.
+             * */
             if (z3Ctx.isInternalFuncDecl(it)) null else it.convertDecl<KSort>()
         }
     }

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Model.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Model.kt
@@ -204,7 +204,10 @@ open class KZ3Model(
                 return
             }
 
-            // Force model constants initialization
+            /**
+             * Force model constants initialization to register all value decls.
+             * See [registerValueDecl] usages.
+             * */
             constantDeclarations
 
             initializeModelValues(model)

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Model.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Model.kt
@@ -47,15 +47,7 @@ open class KZ3Model(
     }
 
     private val interpretations = hashMapOf<KDecl<*>, KModel.KFuncInterp<*>?>()
-
-    private val uninterpretedSortsUniverses =
-        hashMapOf<KUninterpretedSort, Set<KUninterpretedSortValue>>()
-
-    private val uninterpretedSortValueMapping =
-        hashMapOf<KUninterpretedSort, MutableMap<Long, KUninterpretedSortValue>>()
-
-    private val uninterpretedSortValueDecls =
-        hashMapOf<KUninterpretedSort, MutableMap<Long, KUninterpretedSortValue>>()
+    private val uninterpretedSortValues = hashMapOf<KUninterpretedSort, UninterpretedSortValueContext>()
 
     private fun loadConstDeclarations(): Set<KDecl<KSort>> {
         val nativeDecls = model.getNativeConstDecls()
@@ -66,10 +58,8 @@ open class KZ3Model(
                 it.convertDecl<KSort>()
             } else {
                 // internal decl
-                val sortValueDecls = uninterpretedSortValueDecls.getOrPut(uninterpretedSortValue.sort) {
-                    hashMapOf()
-                }
-                sortValueDecls[it] = uninterpretedSortValue
+                val valueContext = getUninterpretedSortContext(uninterpretedSortValue.sort)
+                valueContext.registerValueDecl(it, uninterpretedSortValue)
 
                 // hide declaration in model
                 null
@@ -104,49 +94,33 @@ open class KZ3Model(
         }?.uncheckedCast()
 
     override fun uninterpretedSortUniverse(sort: KUninterpretedSort): Set<KUninterpretedSortValue>? =
-        uninterpretedSortsUniverses.getOrPut(sort) {
+        uninterpretedSortValues.getOrPut(sort) {
             ctx.ensureContextMatch(sort)
-
-            if (sort !in uninterpretedSorts) {
-                return@getOrPut emptySet()
+            getUninterpretedSortContext(sort).also {
+                initializeSortUniverse(it)
             }
+        }.getSortUniverse()
 
-            // Force model constants initialization
-            constantDeclarations
-
-            val sortValues = uninterpretedSortValueDecls[sort] ?: emptyMap()
-
-            var lastValueIdx = 0
-            val valueMapping = uninterpretedSortValueMapping.getOrPut(sort) {
-                hashMapOf()
-            }
-
-            sortValues.forEach { (decl, value) ->
-                val modelValue = model.getConstInterp(decl)
-                    ?: error("Const decl is in model decls but not in the model")
-
-                val modelValueDecl = Native.getAppDecl(z3Ctx.nCtx, modelValue)
-
-                lastValueIdx = maxOf(value.valueIdx, lastValueIdx)
-                valueMapping[modelValueDecl] = value
-            }
-
-            val z3Sort = with(internalizer) { sort.internalizeSort() }
-            val z3SortUniverse = model.getSortUniverse(z3Sort)
-
-            z3SortUniverse.convertToSet {
-                val modelValueDecl = Native.getAppDecl(z3Ctx.nCtx, it)
-                valueMapping.getOrPut(modelValueDecl) {
-                    ctx.mkUninterpretedSortValue(sort, ++lastValueIdx)
-                }
-            }
+    private fun initializeSortUniverse(sortCtx: UninterpretedSortValueContext) {
+        if (sortCtx.sort !in uninterpretedSorts) {
+            return
         }
+
+        // Force model constants initialization
+        constantDeclarations
+
+        sortCtx.initializeModelValues(model)
+
+        val z3Sort = with(internalizer) { sortCtx.sort.internalizeSort() }
+        val z3SortUniverse = model.getSortUniverse(z3Sort)
+
+        sortCtx.initializeSortUniverse(z3SortUniverse)
+    }
 
     internal fun resolveUninterpretedSortValue(sort: KUninterpretedSort, decl: Long): KUninterpretedSortValue {
         uninterpretedSortUniverse(sort) // ensure sort universe initialized
 
-        return uninterpretedSortValueMapping[sort]?.get(decl)
-            ?: error("Unexpected uninterpreted sort value")
+        return getUninterpretedSortContext(sort).getValue(decl)
     }
 
     private fun <T : KSort> constInterp(decl: KDecl<T>, z3Decl: Long): KModel.KFuncInterp<T>? {
@@ -217,5 +191,50 @@ open class KZ3Model(
         }
         z3Ctx.releaseTemporaryAst(preparedExpr)
         return convertedExpr
+    }
+
+    private fun getUninterpretedSortContext(sort: KUninterpretedSort): UninterpretedSortValueContext =
+        uninterpretedSortValues.getOrPut(sort) { UninterpretedSortValueContext(ctx, z3Ctx, sort) }
+
+    private class UninterpretedSortValueContext(
+        val ctx: KContext,
+        val z3Ctx: KZ3Context,
+        val sort: KUninterpretedSort
+    ) {
+        private var currentValueIdx = 0
+        private val declValues = hashMapOf<Long, KUninterpretedSortValue>()
+        private val modelValues = hashMapOf<Long, KUninterpretedSortValue>()
+        private val sortUniverse = hashSetOf<KUninterpretedSortValue>()
+
+        fun registerValueDecl(decl: Long, value: KUninterpretedSortValue) {
+            declValues[decl] = value
+        }
+
+        fun getSortUniverse(): Set<KUninterpretedSortValue> = sortUniverse
+
+        fun initializeModelValues(model: Model) {
+            declValues.forEach { (modelDecl, value) ->
+                val modelValue = model.getConstInterp(modelDecl)
+                    ?: error("Const decl is in model decls but not in the model")
+
+                val modelValueDecl = Native.getAppDecl(z3Ctx.nCtx, modelValue)
+
+                modelValues[modelValueDecl] = value
+                currentValueIdx = maxOf(currentValueIdx, value.valueIdx + 1)
+            }
+        }
+
+        fun initializeSortUniverse(universe: LongArray) {
+            universe.forEach {
+                val modelValueDecl = Native.getAppDecl(z3Ctx.nCtx, it)
+                sortUniverse.add(getValue(modelValueDecl))
+            }
+        }
+
+        fun getValue(decl: Long): KUninterpretedSortValue = modelValues.getOrPut(decl) {
+            mkFreshValue()
+        }
+
+        private fun mkFreshValue() = ctx.mkUninterpretedSortValue(sort, currentValueIdx++)
     }
 }

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Model.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Model.kt
@@ -137,8 +137,7 @@ open class KZ3Model(
             z3SortUniverse.convertToSet {
                 val modelValueDecl = Native.getAppDecl(z3Ctx.nCtx, it)
                 valueMapping.getOrPut(modelValueDecl) {
-                    val valueId = ++lastValueIdx
-                    ctx.mkUninterpretedSortValue(sort, valueId)
+                    ctx.mkUninterpretedSortValue(sort, ++lastValueIdx)
                 }
             }
         }

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3SMTLibParser.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3SMTLibParser.kt
@@ -33,7 +33,7 @@ class KZ3SMTLibParser(private val ctx: KContext) : KSMTLibParser {
     }
 
     private fun parse(parser: Context.() -> Array<BoolExpr>) = try {
-        KZ3Context().use {
+        KZ3Context(ctx).use {
             it.convertAssertions(it.nativeContext.parser().toList())
         }
     } catch (ex: Z3Exception) {

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Solver.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Solver.kt
@@ -112,7 +112,7 @@ open class KZ3Solver(private val ctx: KContext) : KSolver<KZ3SolverConfiguration
         }
         val model = solver.model
 
-        KZ3Model(model, ctx, z3Ctx, exprInternalizer, exprConverter)
+        KZ3Model(model, ctx, z3Ctx, exprInternalizer)
     }
 
     // TODO add mapping back from tracked variable into initial value

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Solver.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Solver.kt
@@ -52,6 +52,7 @@ open class KZ3Solver(private val ctx: KContext) : KSolver<KZ3SolverConfiguration
 
     override fun push() {
         solver.push()
+        z3Ctx.pushAssertionLevel()
         currentScope++
     }
 
@@ -60,7 +61,10 @@ open class KZ3Solver(private val ctx: KContext) : KSolver<KZ3SolverConfiguration
             "Can not pop $n scope levels because current scope level is $currentScope"
         }
         if (n == 0u) return
+
         solver.pop(n.toInt())
+        repeat(n.toInt()) { z3Ctx.popAssertionLevel() }
+
         currentScope -= n
     }
 
@@ -69,6 +73,8 @@ open class KZ3Solver(private val ctx: KContext) : KSolver<KZ3SolverConfiguration
 
         val z3Expr = with(exprInternalizer) { expr.internalizeExpr() }
         solver.solverAssert(z3Expr)
+
+        z3Ctx.assertPendingAxioms(solver)
     }
 
     override fun assertAndTrack(expr: KExpr<KBoolSort>, trackVar: KConstDecl<KBoolSort>) = z3Try {

--- a/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Solver.kt
+++ b/ksmt-z3/src/main/kotlin/org/ksmt/solver/z3/KZ3Solver.kt
@@ -23,7 +23,7 @@ import kotlin.time.Duration
 import kotlin.time.DurationUnit
 
 open class KZ3Solver(private val ctx: KContext) : KSolver<KZ3SolverConfiguration> {
-    private val z3Ctx = KZ3Context()
+    private val z3Ctx = KZ3Context(ctx)
     private val solver = createSolver()
     private var lastCheckStatus = KSolverStatus.UNKNOWN
     private var currentScope: UInt = 0u

--- a/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/ArrayTest.kt
+++ b/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/ArrayTest.kt
@@ -107,8 +107,8 @@ class ArrayTest {
 
         val ctx = this
         Context().use { z3Native ->
-            val z3InternCtx = KZ3Context(z3Native)
-            val z3ConvertCtx = KZ3Context(z3Native)
+            val z3InternCtx = KZ3Context(this, z3Native)
+            val z3ConvertCtx = KZ3Context(this, z3Native)
 
             with(KZ3ExprInternalizer(ctx, z3InternCtx)) {
                 val iConst = const.internalizeExpr()

--- a/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/FloatingPointTest.kt
+++ b/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/FloatingPointTest.kt
@@ -687,7 +687,7 @@ class FloatingPointTest {
         sort: S,
         operation: (S) -> KExpr<S>,
         solverInternal: Context.(FPSort) -> Expr<*>
-    ) = KZ3Context().use { solverInternalCtx ->
+    ) = KZ3Context(context).use { solverInternalCtx ->
         val internalizer = KZ3ExprInternalizer(context, solverInternalCtx)
 
         val solverInternalSort = with(internalizer) { sort.internalizeSort() }

--- a/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/UninterpretedSortValueTest.kt
+++ b/ksmt-z3/src/test/kotlin/org/ksmt/solver/z3/UninterpretedSortValueTest.kt
@@ -1,0 +1,87 @@
+package org.ksmt.solver.z3
+
+import org.ksmt.KContext
+import org.ksmt.expr.KExpr
+import org.ksmt.expr.KUninterpretedSortValue
+import org.ksmt.solver.KSolverStatus
+import org.ksmt.sort.KUninterpretedSort
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class UninterpretedSortValueTest {
+    private val ctx = KContext(simplificationMode = KContext.SimplificationMode.NO_SIMPLIFY)
+    private val solver = KZ3Solver(ctx)
+
+    @Test
+    fun testUninterpretedSortValueDistinct() = with(ctx) {
+        val sort = mkUninterpretedSort("T")
+        val value0 = mkUninterpretedSortValue(sort, 0)
+        val value1 = mkUninterpretedSortValue(sort, 1)
+
+        solver.push()
+
+        solver.assert(value0 eq value1)
+
+        assertEquals(KSolverStatus.UNSAT, solver.check())
+
+        solver.pop()
+
+        // Internalization skipped
+        solver.assert(value0 eq value1)
+
+        assertEquals(KSolverStatus.UNSAT, solver.check())
+    }
+
+    @Test
+    fun testUninterpretedSortValueModel() = with(ctx) {
+        val sort = mkUninterpretedSort("T")
+        val value0 = mkUninterpretedSortValue(sort, 0)
+        val value1 = mkUninterpretedSortValue(sort, 1)
+
+        val var0 = mkConst("v0", sort)
+        val var1 = mkConst("v1", sort)
+        val var2 = mkConst("v2", sort)
+
+        solver.assert(var0 eq value1)
+        solver.assert(var1 eq value0)
+
+        solver.push()
+
+        solver.assert(var0 eq var1)
+        assertEquals(KSolverStatus.UNSAT, solver.check())
+
+        solver.pop()
+
+        solver.push()
+        checkSatAndValidateModel(var0, var1, var2, value0, value1)
+        solver.pop()
+
+        checkSatAndValidateModel(var0, var1, var2, value0, value1)
+    }
+
+    private fun KContext.checkSatAndValidateModel(
+        var0: KExpr<KUninterpretedSort>,
+        var1: KExpr<KUninterpretedSort>,
+        var2: KExpr<KUninterpretedSort>,
+        value0: KUninterpretedSortValue,
+        value1: KUninterpretedSortValue,
+    ) {
+        solver.assert(mkDistinct(listOf(var0, var1, var2)))
+        assertEquals(KSolverStatus.SAT, solver.check())
+
+        val model = solver.model()
+
+        val modelValue0 = model.eval(var0, isComplete = false)
+        val modelValue1 = model.eval(var1, isComplete = false)
+        val modelValue2 = model.eval(var2, isComplete = false)
+
+        assertEquals(value0, modelValue1)
+        assertEquals(value1, modelValue0)
+
+        assertTrue(modelValue2 is KUninterpretedSortValue)
+        assertNotEquals(value0, modelValue2)
+        assertNotEquals(value1, modelValue2)
+    }
+}


### PR DESCRIPTION
Add interpreted values of an uninterpreted sorts.

### Implementation details
* Yices --- native support for uninterpreted sort values.
* Bitwuzla --- almost native support, since we represent uninterpreted sorts as Bv32.
* Z3 --- no native support. We use uninterpreted constants with handcrafted distinct constraints. Also, we preciselly track the set of currently asserted values, to keep sort universe as small as possible. 
* Cvc5 --- no native support. We use the same approach as in Z3. 

### Other/related changes
* Tests for uninterpreted sort values.
* Support for uninterpreted values in `TestWorker`.
* FIx declarations serialization.
* Rework Z3 converter caches since we now have expressions that are only valid within a single model.