### PR TITLE
Fix unsat core generation

### DIFF
--- a/ksmt-bitwuzla/src/main/kotlin/io/ksmt/solver/bitwuzla/KBitwuzlaContext.kt
+++ b/ksmt-bitwuzla/src/main/kotlin/io/ksmt/solver/bitwuzla/KBitwuzlaContext.kt
@@ -298,7 +298,9 @@ open class KBitwuzlaContext(val ctx: KContext) : AutoCloseable {
     }
 
     override fun close() {
+        if (isClosed) return
         isClosed = true
+
         sorts.clear()
         bitwuzlaSorts.clear()
 

--- a/ksmt-cvc5/src/main/kotlin/io/ksmt/solver/cvc5/KCvc5Context.kt
+++ b/ksmt-cvc5/src/main/kotlin/io/ksmt/solver/cvc5/KCvc5Context.kt
@@ -351,6 +351,7 @@ class KCvc5Context(
 
 
     override fun close() {
+        if (isClosed) return
         isClosed = true
 
         currentScopeExpressions.clear()

--- a/ksmt-test/src/test/kotlin/io/ksmt/test/CheckWithAssumptionsTest.kt
+++ b/ksmt-test/src/test/kotlin/io/ksmt/test/CheckWithAssumptionsTest.kt
@@ -38,6 +38,18 @@ class CheckWithAssumptionsTest {
     @Test
     fun testUnsatCoreGenerationCvc() = testUnsatCoreGeneration { KCvc5Solver(it) }
 
+    @Test
+    fun testTrivialUnsatCoreZ3() = testTrivialUnsatCore { KZ3Solver(it) }
+
+    @Test
+    fun testTrivialUnsatCoreBitwuzla() = testTrivialUnsatCore { KBitwuzlaSolver(it) }
+
+    @Test
+    fun testTrivialUnsatCoreYices() = testTrivialUnsatCore { KYicesSolver(it) }
+
+    @Test
+    fun testTrivialUnsatCoreCvc() = testTrivialUnsatCore { KCvc5Solver(it) }
+
     private fun testComplexAssumption(mkSolver: (KContext) -> KSolver<*>) = with(KContext()) {
         mkSolver(this).use { solver ->
             val a by bv32Sort
@@ -74,6 +86,17 @@ class CheckWithAssumptionsTest {
 
             assertTrue(e2 in core)
             assertTrue(e3 in core)
+        }
+    }
+
+    private fun testTrivialUnsatCore(mkSolver: (KContext) -> KSolver<*>) = with(KContext()) {
+        mkSolver(this).use { solver ->
+            val status = solver.checkWithAssumptions(listOf(falseExpr))
+            assertEquals(KSolverStatus.UNSAT, status)
+
+            val core = solver.unsatCore()
+            assertEquals(1, core.size)
+            assertTrue(falseExpr in core)
         }
     }
 }

--- a/ksmt-z3/src/main/kotlin/io/ksmt/solver/z3/KZ3Context.kt
+++ b/ksmt-z3/src/main/kotlin/io/ksmt/solver/z3/KZ3Context.kt
@@ -261,6 +261,7 @@ class KZ3Context(
     }
 
     override fun close() {
+        if (isClosed) return
         isClosed = true
 
         z3Expressions.keys.decRefAll()


### PR DESCRIPTION
* Fix solver close. Don't close when the solver is already closed.
* Fix trivial unsat core handling in Z3 (#112).